### PR TITLE
Add RecurringEventGroup

### DIFF
--- a/appointment.go
+++ b/appointment.go
@@ -17,6 +17,14 @@ const (
 	AppointmentModeVideo    = "VIDEO"
 )
 
+type TimeSlotType string
+
+const (
+	AppointmentTimeSlotTypeAppointment     TimeSlotType = "appointment"
+	AppointmentTimeSlotTypeAppointmentSlot TimeSlotType = "appointment_slot"
+	AppointmentTimeSlotTypeEvent           TimeSlotType = "event"
+)
+
 type AppointmentServicer interface {
 	Create(ctx context.Context, create *AppointmentCreate) (*Appointment, *http.Response, error)
 	Find(ctx context.Context, opts *FindAppointmentsOptions) (*Response[[]*Appointment], *http.Response, error)

--- a/client.go
+++ b/client.go
@@ -36,21 +36,22 @@ type Client struct {
 	baseURL    string
 	tracer     trace.Tracer
 
-	AppointmentSvc          *AppointmentService
-	ClinicalDocumentSvc     *ClinicalDocumentService
-	ContactSvc              *ContactService
-	InsuranceCompanySvc     *InsuranceCompanyService
-	InsuranceEligibilitySvc *InsuranceEligibilityService
-	InsurancePlanSvc        *InsurancePlanService
-	LetterSvc               *LetterService
-	MedicationSvc           *MedicationService
-	NonVisitNoteSvc         *NonVisitNoteService
-	PatientSvc              *PatientService
-	PhysicianSvc            *PhysicianService
-	PracticeSvc             *PracticeService
-	ProblemSvc              *ProblemService
-	ServiceLocationSvc      *ServiceLocationService
-	SubscriptionSvc         *SubscriptionService
+	AppointmentSvc             *AppointmentService
+	ClinicalDocumentSvc        *ClinicalDocumentService
+	ContactSvc                 *ContactService
+	InsuranceCompanySvc        *InsuranceCompanyService
+	InsuranceEligibilitySvc    *InsuranceEligibilityService
+	InsurancePlanSvc           *InsurancePlanService
+	LetterSvc                  *LetterService
+	MedicationSvc              *MedicationService
+	NonVisitNoteSvc            *NonVisitNoteService
+	PatientSvc                 *PatientService
+	PhysicianSvc               *PhysicianService
+	PracticeSvc                *PracticeService
+	ProblemSvc                 *ProblemService
+	RecurringEventGroupService *RecurringEventGroupService
+	ServiceLocationSvc         *ServiceLocationService
+	SubscriptionSvc            *SubscriptionService
 }
 
 func NewClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseURL string) *Client {
@@ -81,6 +82,7 @@ func NewClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseUR
 	client.PhysicianSvc = &PhysicianService{client}
 	client.PracticeSvc = &PracticeService{client}
 	client.ProblemSvc = &ProblemService{client}
+	client.RecurringEventGroupService = &RecurringEventGroupService{client}
 	client.ServiceLocationSvc = &ServiceLocationService{client}
 	client.SubscriptionSvc = &SubscriptionService{client}
 

--- a/recurring_event_group.go
+++ b/recurring_event_group.go
@@ -1,0 +1,160 @@
+package elation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type RecurringEventGroupServicer interface {
+	Create(ctx context.Context, create *RecurringEventGroupCreate) (*RecurringEventGroup, *http.Response, error)
+	Find(ctx context.Context, opts *FindRecurringEventGroupsOptions) (*Response[[]*RecurringEventGroup], *http.Response, error)
+	Get(ctx context.Context, id int64) (*RecurringEventGroup, *http.Response, error)
+	Update(ctx context.Context, id int64, update *RecurringEventGroupUpdate) (*RecurringEventGroup, *http.Response, error)
+	Delete(ctx context.Context, id int64) (*http.Response, error)
+}
+
+var _ RecurringEventGroupServicer = (*RecurringEventGroupService)(nil)
+
+type RecurringEventGroupService struct {
+	client *Client
+}
+
+type RecurringEventGroupSchedule struct {
+	ID           int64     `json:"id"`
+	SeriesStart  string    `json:"series_start"`
+	SeriesStop   string    `json:"series_stop"`
+	EventTime    string    `json:"event_time"`
+	Physician    int64     `json:"physician"`
+	Duration     int       `json:"duration"`
+	Repeats      string    `json:"repeats"`
+	DOWMonday    bool      `json:"dow_monday"`
+	DOWTuesday   bool      `json:"dow_tuesday"`
+	DOWWednesday bool      `json:"dow_wednesday"`
+	DOWThursday  bool      `json:"dow_thursday"`
+	DOWFriday    bool      `json:"dow_friday"`
+	DOWSaturday  bool      `json:"dow_saturday"`
+	DOWSunday    bool      `json:"dow_sunday"`
+	Description  string    `json:"description"`
+	CreatedDate  time.Time `json:"created_date"`
+}
+
+type RecurringEventGroup struct {
+	ID       int64 `json:"id"`
+	Practice int64 `json:"practice"`
+
+	CreatedDate time.Time  `json:"created_date"`
+	DeletedDate *time.Time `json:"deleted_date"`
+
+	Description  string                         `json:"description"`
+	Reason       string                         `json:"reason"`
+	Schedules    []*RecurringEventGroupSchedule `json:"schedules"`
+	TimeSlotType TimeSlotType                   `json:"time_slot_type"`
+}
+
+type RecurringEventGroupCreate struct {
+	Practice     int64                          `json:"practice"`
+	Reason       string                         `json:"reason"`
+	Schedules    []*RecurringEventGroupSchedule `json:"schedules"`
+	TimeSlotType TimeSlotType                   `json:"time_slot_type"`
+}
+
+func (s *RecurringEventGroupService) Create(ctx context.Context, create *RecurringEventGroupCreate) (*RecurringEventGroup, *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "create recurring event group", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	out := &RecurringEventGroup{}
+
+	res, err := s.client.request(ctx, http.MethodPost, "/recurring_event_groups", nil, create, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}
+
+type FindRecurringEventGroupsOptions struct {
+	*Pagination
+
+	Physician    []int64      `url:"physician,omitempty"`
+	Practice     []int64      `url:"practice,omitempty"`
+	Reason       string       `url:"reason,omitempty"`
+	StartDate    time.Time    `url:"start_date,omitempty"`
+	EndDate      time.Time    `url:"end_date,omitempty"`
+	TimeSlotType TimeSlotType `url:"time_slot_type,omitempty"`
+}
+
+func (s *RecurringEventGroupService) Find(ctx context.Context, opts *FindRecurringEventGroupsOptions) (*Response[[]*RecurringEventGroup], *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "find recurring event groups", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	out := &Response[[]*RecurringEventGroup]{}
+
+	res, err := s.client.request(ctx, http.MethodGet, "/recurring_event_groups", opts, nil, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}
+
+func (s *RecurringEventGroupService) Get(ctx context.Context, id int64) (*RecurringEventGroup, *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "get recurring event group", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.Int64("elation.recurring_event_group_id", id)))
+	defer span.End()
+
+	out := &RecurringEventGroup{}
+
+	res, err := s.client.request(ctx, http.MethodGet, "/recurring_event_groups/"+strconv.FormatInt(id, 10), nil, nil, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}
+
+type RecurringEventGroupUpdate struct {
+	Reason    string                         `json:"reason"`
+	Schedules []*RecurringEventGroupSchedule `json:"schedules"`
+}
+
+func (s *RecurringEventGroupService) Update(ctx context.Context, id int64, update *RecurringEventGroupUpdate) (*RecurringEventGroup, *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "update recurring event group", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.Int64("elation.recurring_event_group_id", id)))
+	defer span.End()
+
+	out := &RecurringEventGroup{}
+
+	res, err := s.client.request(ctx, http.MethodPatch, "/recurring_event_groups/"+strconv.FormatInt(id, 10), nil, update, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}
+
+func (s *RecurringEventGroupService) Delete(ctx context.Context, id int64) (*http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "delete recurring event group", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.Int64("elation.recurring_event_group_id", id)))
+	defer span.End()
+
+	res, err := s.client.request(ctx, http.MethodDelete, "/recurring_event_groups/"+strconv.FormatInt(id, 10), nil, nil, nil)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return res, fmt.Errorf("making request: %w", err)
+	}
+
+	return res, nil
+}

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -1,0 +1,263 @@
+package elation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecurringEventGroupService_Create(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := &RecurringEventGroupCreate{
+		Practice: 1,
+		Reason:   "Appt follow-up",
+		Schedules: []*RecurringEventGroupSchedule{
+			{
+				ID:           5,
+				SeriesStart:  "2024-01-01",
+				SeriesStop:   "2024-02-01",
+				EventTime:    "10:30:00",
+				Physician:    2,
+				Duration:     15,
+				Repeats:      "Weekly",
+				DOWMonday:    true,
+				DOWTuesday:   false,
+				DOWWednesday: false,
+				DOWThursday:  false,
+				DOWFriday:    false,
+				DOWSaturday:  false,
+				DOWSunday:    false,
+				Description:  "Appt follow-up",
+				CreatedDate:  time.Date(2024, 3, 27, 10, 30, 0, 0, time.UTC),
+			},
+		},
+		TimeSlotType: AppointmentTimeSlotTypeAppointmentSlot,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/recurring_event_groups", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(err)
+
+		actual := &RecurringEventGroupCreate{}
+		err = json.Unmarshal(body, actual)
+		assert.NoError(err)
+
+		assert.Equal(expected, actual)
+
+		b, err := json.Marshal(&Appointment{})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	created, res, err := svc.Create(context.Background(), expected)
+	assert.NotNil(created)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestRecurringEventGroupService_Find(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := &FindRecurringEventGroupsOptions{
+		Pagination: &Pagination{
+			Limit:  1,
+			Offset: 2,
+		},
+
+		Physician:    []int64{1},
+		Practice:     []int64{2},
+		Reason:       "Some reason",
+		TimeSlotType: AppointmentTimeSlotTypeEvent,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/recurring_event_groups", r.URL.Path)
+
+		practice := r.URL.Query()["practice"]
+		physician := r.URL.Query()["physician"]
+		reason := r.URL.Query().Get("reason")
+		timeSlotType := r.URL.Query().Get("time_slot_type")
+
+		limit := r.URL.Query().Get("limit")
+		offset := r.URL.Query().Get("offset")
+
+		assert.Equal(opts.Practice, sliceStrToInt64(practice))
+		assert.Equal(opts.Physician, sliceStrToInt64(physician))
+		assert.Equal(opts.Reason, reason)
+		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
+
+		assert.Equal(opts.Pagination.Limit, strToInt(limit))
+		assert.Equal(opts.Pagination.Offset, strToInt(offset))
+
+		b, err := json.Marshal(Response[[]*RecurringEventGroup]{
+			Results: []*RecurringEventGroup{
+				{
+					ID: 1,
+				},
+				{
+					ID: 2,
+				},
+			},
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	found, res, err := svc.Find(context.Background(), opts)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestRecurringEventGroupService_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 1
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/recurring_event_groups/"+strconv.FormatInt(id, 10), r.URL.Path)
+
+		b, err := json.Marshal(&RecurringEventGroup{
+			ID: id,
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	found, res, err := svc.Get(context.Background(), id)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestRecurringEventGroupService_Update(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 1
+	expected := &RecurringEventGroupUpdate{
+		Reason: "Appt follow-up",
+		Schedules: []*RecurringEventGroupSchedule{
+			{
+				ID:           5,
+				SeriesStart:  "2024-01-01",
+				SeriesStop:   "2024-03-01",
+				EventTime:    "11:00:00",
+				Physician:    2,
+				Duration:     15,
+				Repeats:      "Weekly",
+				DOWMonday:    true,
+				DOWTuesday:   true,
+				DOWWednesday: false,
+				DOWThursday:  false,
+				DOWFriday:    false,
+				DOWSaturday:  false,
+				DOWSunday:    false,
+				Description:  "Appt follow-up",
+				CreatedDate:  time.Date(2024, 3, 27, 10, 30, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodPatch, r.Method)
+		assert.Equal("/recurring_event_groups/"+strconv.FormatInt(id, 10), r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(err)
+
+		actual := &RecurringEventGroupUpdate{}
+		err = json.Unmarshal(body, actual)
+		assert.NoError(err)
+
+		assert.Equal(expected, actual)
+
+		b, err := json.Marshal(&RecurringEventGroup{})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	found, res, err := svc.Update(context.Background(), id, expected)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestRecurringEventGroupService_Delete(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 1
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodDelete, r.Method)
+		assert.Equal("/recurring_event_groups/"+strconv.FormatInt(id, 10), r.URL.Path)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	res, err := svc.Delete(context.Background(), id)
+	assert.NotNil(res)
+	assert.NoError(err)
+}


### PR DESCRIPTION
Add support for [RecurringEventGroups](https://docs.elationhealth.com/reference/alpha-the-recurring-event-group-object)

Relevant documentation regarding `time_slot_type` values:

* [Event](https://docs.elationhealth.com/reference/the-event-object-1)
* [Appointment](https://docs.elationhealth.com/reference/the-appointment-object)
* [Appointment Slot](https://docs.elationhealth.com/reference/the-appointment-slot-object-1)