### PR TITLE
Change date params to strings for REG Find

### DIFF
--- a/recurring_event_group.go
+++ b/recurring_event_group.go
@@ -87,8 +87,8 @@ type FindRecurringEventGroupsOptions struct {
 	Physician    []int64      `url:"physician,omitempty"`
 	Practice     []int64      `url:"practice,omitempty"`
 	Reason       string       `url:"reason,omitempty"`
-	StartDate    time.Time    `url:"start_date,omitempty"`
-	EndDate      time.Time    `url:"end_date,omitempty"`
+	StartDate    string       `url:"start_date,omitempty"`
+	EndDate      string       `url:"end_date,omitempty"`
 	TimeSlotType TimeSlotType `url:"time_slot_type,omitempty"`
 }
 

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -90,6 +90,8 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		Practice:     []int64{2},
 		Reason:       "Some reason",
 		TimeSlotType: AppointmentTimeSlotTypeEvent,
+		StartDate:    "2024-01-01",
+		EndDate:      "2024-03-01",
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -104,6 +106,8 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		physician := r.URL.Query()["physician"]
 		reason := r.URL.Query().Get("reason")
 		timeSlotType := r.URL.Query().Get("time_slot_type")
+		startDate := r.URL.Query().Get("start_date")
+		endDate := r.URL.Query().Get("end_date")
 
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
@@ -112,6 +116,8 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		assert.Equal(opts.Physician, sliceStrToInt64(physician))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
+		assert.Equal(opts.StartDate, startDate)
+		assert.Equal(opts.EndDate, endDate)
 
 		assert.Equal(opts.Pagination.Limit, strToInt(limit))
 		assert.Equal(opts.Pagination.Offset, strToInt(offset))


### PR DESCRIPTION
This is not documented in the API but the start and end date fields are not timestamps but rather formatted date strings in the format `YYYY-MM-DD` 

```json
{"detail":"['“2024-04-01T11:12:31-04:00” value has an invalid date format. It must be in YYYY-MM-DD format.']"}
```

https://docs.elationhealth.com/reference/find-recurring-event-group