### PR TITLE
Fix array params

### DIFF
--- a/elation_test.go
+++ b/elation_test.go
@@ -18,17 +18,19 @@ func tokenRequest(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-func commaStrToInt64(in string) []int64 {
+func sliceCommaStrToInt64(in []string) []int64 {
 	var out []int64
 
-	for _, v := range strings.Split(in, ",") {
-		i, err := strconv.ParseInt(v, 10, 64)
+	for _, commaStr := range in {
+		for _, v := range strings.Split(commaStr, ",") {
+			i, err := strconv.ParseInt(v, 10, 64)
 
-		if err != nil {
-			panic(err)
+			if err != nil {
+				panic(err)
+			}
+
+			out = append(out, i)
 		}
-
-		out = append(out, i)
 	}
 
 	return out

--- a/elation_test.go
+++ b/elation_test.go
@@ -18,19 +18,17 @@ func tokenRequest(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-func sliceCommaStrToInt64(in []string) []int64 {
+func commaStrToInt64(in string) []int64 {
 	var out []int64
 
-	for _, commaStr := range in {
-		for _, v := range strings.Split(commaStr, ",") {
-			i, err := strconv.ParseInt(v, 10, 64)
+	for _, v := range strings.Split(in, ",") {
+		i, err := strconv.ParseInt(v, 10, 64)
 
-			if err != nil {
-				panic(err)
-			}
-
-			out = append(out, i)
+		if err != nil {
+			panic(err)
 		}
+
+		out = append(out, i)
 	}
 
 	return out

--- a/elation_test.go
+++ b/elation_test.go
@@ -3,6 +3,7 @@ package elation
 import (
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func tokenRequest(w http.ResponseWriter, r *http.Request) bool {
@@ -15,6 +16,22 @@ func tokenRequest(w http.ResponseWriter, r *http.Request) bool {
 	w.Write([]byte(`{"access_token":"foo"}`))
 
 	return true
+}
+
+func commaStrToInt64(in string) []int64 {
+	var out []int64
+
+	for _, v := range strings.Split(in, ",") {
+		i, err := strconv.ParseInt(v, 10, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		out = append(out, i)
+	}
+
+	return out
 }
 
 func sliceStrToInt64(in []string) []int64 {

--- a/recurring_event_group.go
+++ b/recurring_event_group.go
@@ -84,8 +84,8 @@ func (s *RecurringEventGroupService) Create(ctx context.Context, create *Recurri
 type FindRecurringEventGroupsOptions struct {
 	*Pagination
 
-	Physician    []int64      `url:"physician,omitempty"`
-	Practice     []int64      `url:"practice,omitempty"`
+	Physician    []int64      `url:"physician,omitempty,comma"`
+	Practice     []int64      `url:"practice,omitempty,comma"`
 	Reason       string       `url:"reason,omitempty"`
 	StartDate    string       `url:"start_date,omitempty"`
 	EndDate      string       `url:"end_date,omitempty"`

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -112,8 +112,80 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
 
-		assert.Equal(opts.Practice, sliceStrToInt64(practice))
-		assert.Equal(opts.Physician, sliceStrToInt64(physician))
+		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
+		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
+		assert.Equal(opts.Reason, reason)
+		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
+		assert.Equal(opts.StartDate, startDate)
+		assert.Equal(opts.EndDate, endDate)
+
+		assert.Equal(opts.Pagination.Limit, strToInt(limit))
+		assert.Equal(opts.Pagination.Offset, strToInt(offset))
+
+		b, err := json.Marshal(Response[[]*RecurringEventGroup]{
+			Results: []*RecurringEventGroup{
+				{
+					ID: 1,
+				},
+				{
+					ID: 2,
+				},
+			},
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := RecurringEventGroupService{client}
+
+	found, res, err := svc.Find(context.Background(), opts)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestRecurringEventGroupService_Find_Multiple_Params(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := &FindRecurringEventGroupsOptions{
+		Pagination: &Pagination{
+			Limit:  1,
+			Offset: 2,
+		},
+
+		Physician:    []int64{1, 2, 3},
+		Practice:     []int64{7, 8, 9},
+		Reason:       "Some reason",
+		TimeSlotType: AppointmentTimeSlotTypeEvent,
+		StartDate:    "2024-01-01",
+		EndDate:      "2024-03-01",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/recurring_event_groups", r.URL.Path)
+
+		practice := r.URL.Query()["practice"]
+		physician := r.URL.Query()["physician"]
+		reason := r.URL.Query().Get("reason")
+		timeSlotType := r.URL.Query().Get("time_slot_type")
+		startDate := r.URL.Query().Get("start_date")
+		endDate := r.URL.Query().Get("end_date")
+
+		limit := r.URL.Query().Get("limit")
+		offset := r.URL.Query().Get("offset")
+
+		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
+		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
 		assert.Equal(opts.StartDate, startDate)

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -112,8 +112,8 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
 
-		assert.Equal(opts.Practice, sliceCommaStrToInt64(practice))
-		assert.Equal(opts.Physician, sliceCommaStrToInt64(physician))
+		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
+		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
 		assert.Equal(opts.StartDate, startDate)
@@ -184,8 +184,8 @@ func TestRecurringEventGroupService_Find_Multiple_Params(t *testing.T) {
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
 
-		assert.Equal(opts.Practice, sliceCommaStrToInt64(practice))
-		assert.Equal(opts.Physician, sliceCommaStrToInt64(physician))
+		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
+		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
 		assert.Equal(opts.StartDate, startDate)

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -112,8 +112,8 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
 
-		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
-		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
+		assert.Equal(opts.Practice, sliceCommaStrToInt64(practice))
+		assert.Equal(opts.Physician, sliceCommaStrToInt64(physician))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
 		assert.Equal(opts.StartDate, startDate)
@@ -184,8 +184,8 @@ func TestRecurringEventGroupService_Find_Multiple_Params(t *testing.T) {
 		limit := r.URL.Query().Get("limit")
 		offset := r.URL.Query().Get("offset")
 
-		assert.Equal(opts.Practice, commaStrToInt64(practice[0]))
-		assert.Equal(opts.Physician, commaStrToInt64(physician[0]))
+		assert.Equal(opts.Practice, sliceCommaStrToInt64(practice))
+		assert.Equal(opts.Physician, sliceCommaStrToInt64(physician))
 		assert.Equal(opts.Reason, reason)
 		assert.Equal(opts.TimeSlotType, TimeSlotType(timeSlotType))
 		assert.Equal(opts.StartDate, startDate)


### PR DESCRIPTION
Our previous implementation of options with arrays encoded those into URL query params in the following format, with one key-value pair per array item:

`physician=1&physician=2&physician=3`

When testing RecurringEventGroups I noticed the API did not work with this format, and @willfitze identified that the expected param structure is one key with a comma-separated list of values:

`physician=1%2C2%2C3`

I tested, verified, and fixed this for both array params in the REG API (`physician` and `practice`). 

Per Elation this is a bug that will be addressed in the near future, but making this change  will allow us to use the API with multiple providers temporarily while the bug persists.