### PR TITLE
Extend Create Appointment request

### DIFF
--- a/appointment.go
+++ b/appointment.go
@@ -40,11 +40,14 @@ type AppointmentService struct {
 }
 
 type AppointmentCreate struct {
-	ScheduledDate time.Time `json:"scheduled_date"`
-	Reason        string    `json:"reason"`
-	Patient       int64     `json:"patient"`
-	Physician     int64     `json:"physician"`
-	Practice      int64     `json:"practice"`
+	Description     *string   `json:"description"`
+	Duration        int64     `json:"duration"`
+	Patient         int64     `json:"patient"`
+	Physician       int64     `json:"physician"`
+	Practice        int64     `json:"practice"`
+	Reason          string    `json:"reason"`
+	ScheduledDate   time.Time `json:"scheduled_date"`
+	ServiceLocation *int64    `json:"service_location"`
 }
 
 func (s *AppointmentService) Create(ctx context.Context, create *AppointmentCreate) (*Appointment, *http.Response, error) {

--- a/appointment_test.go
+++ b/appointment_test.go
@@ -16,12 +16,17 @@ import (
 func TestAppointmentService_Create(t *testing.T) {
 	assert := assert.New(t)
 
+	var serviceLocation int64 = 4
+
 	expected := &AppointmentCreate{
-		ScheduledDate: time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC),
-		Reason:        "reason",
-		Patient:       1,
-		Physician:     2,
-		Practice:      3,
+		Description:     Ptr("description"),
+		Duration:        60,
+		Patient:         1,
+		Physician:       2,
+		Practice:        3,
+		Reason:          "reason",
+		ScheduledDate:   time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC),
+		ServiceLocation: Ptr(serviceLocation),
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds `Description`, `Duration`, and `ServiceLocation` to the Create Appointment request per the [Elation API docs](https://docs.elationhealth.com/reference/create-appointment)

Elation documents `Duration` as an optional field but it does appear to be required based on API errors returned when  left missing/null - `{"duration":["This field may not be null."]}`