### PR TITLE
Split Client into an interface and an implementation

### DIFF
--- a/appointment.go
+++ b/appointment.go
@@ -36,7 +36,7 @@ type AppointmentServicer interface {
 var _ AppointmentServicer = (*AppointmentService)(nil)
 
 type AppointmentService struct {
-	client *Client
+	client *HttpClient
 }
 
 type AppointmentCreate struct {

--- a/appointment_test.go
+++ b/appointment_test.go
@@ -55,7 +55,7 @@ func TestAppointmentService_Create(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := AppointmentService{client}
 
 	created, res, err := svc.Create(context.Background(), expected)
@@ -127,7 +127,7 @@ func TestAppointmentService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := AppointmentService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -160,7 +160,7 @@ func TestAppointmentService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := AppointmentService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -210,7 +210,7 @@ func TestAppointmentService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := AppointmentService{client}
 
 	found, res, err := svc.Update(context.Background(), id, expected)
@@ -234,7 +234,7 @@ func TestAppointmentService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := AppointmentService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/cli/cmd/messaging.go
+++ b/cli/cmd/messaging.go
@@ -16,8 +16,8 @@ var (
 
 var findThreadMembersCmd = &cobra.Command{
 	Use: "find-thread-members",
-	Run: wrapRunFunc(func(ctx context.Context, client *elation.Client, args []string) error {
-		response, _, err := client.ThreadMemberSvc.Find(ctx, &elation.FindThreadMembersOptions{
+	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
+		response, _, err := client.ThreadMembers().Find(ctx, &elation.FindThreadMembersOptions{
 			Patient: findThreadMembersPatients,
 			User:    findThreadMembersUsers,
 		})
@@ -34,9 +34,9 @@ var findThreadMembersCmd = &cobra.Command{
 var getMessageThreadCmd = &cobra.Command{
 	Use:  "get-message-thread [thread ID]",
 	Args: cobra.ExactArgs(1),
-	Run: wrapRunFunc(func(ctx context.Context, client *elation.Client, args []string) error {
+	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
 		threadID, _ := strconv.ParseInt(args[0], 10, 64)
-		response, _, err := client.MessageThreadSvc.Get(ctx, threadID)
+		response, _, err := client.MessageThreads().Get(ctx, threadID)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/practice.go
+++ b/cli/cmd/practice.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/authorhealth/go-elation"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+)
+
+var findPhysiciansCmd = &cobra.Command{
+	Use: "find-physicians",
+	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
+		response, _, err := client.Physicians().Find(ctx, &elation.FindPhysiciansOptions{})
+		if err != nil {
+			return err
+		}
+
+		spew.Dump(response)
+
+		return nil
+	}),
+}
+
+func init() {
+	rootCmd.AddCommand(findPhysiciansCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,7 +25,7 @@ func Execute() {
 	}
 }
 
-type runFunc func(ctx context.Context, client *elation.Client, args []string) error
+type runFunc func(ctx context.Context, client elation.Client, args []string) error
 
 func wrapRunFunc(runFunc runFunc) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
@@ -36,7 +36,7 @@ func wrapRunFunc(runFunc runFunc) func(cmd *cobra.Command, args []string) {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 		slog.SetDefault(logger)
 
-		client := elation.NewClient(
+		client := elation.NewHttpClient(
 			&http.Client{
 				Timeout: 15 * time.Second,
 			},

--- a/client.go
+++ b/client.go
@@ -128,63 +128,83 @@ func NewHttpClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 func (c *HttpClient) Appointments() AppointmentServicer {
 	return c.AppointmentSvc
 }
+
 func (c *HttpClient) ClinicalDocuments() ClinicalDocumentServicer {
 	return c.ClinicalDocumentSvc
 }
+
 func (c *HttpClient) Contacts() ContactServicer {
 	return c.ContactSvc
 }
+
 func (c *HttpClient) DiscontinuedMedications() DiscontinuedMedicationServicer {
 	return c.DiscontinuedMedicationSvc
 }
+
 func (c *HttpClient) HistoryDownloadFills() HistoryDownloadFillServicer {
 	return c.HistoryDownloadFillSvc
 }
+
 func (c *HttpClient) InsuranceCompanies() InsuranceCompanyServicer {
 	return c.InsuranceCompanySvc
 }
+
 func (c *HttpClient) InsuranceEligibility() InsuranceEligibilityServicer {
 	return c.InsuranceEligibilitySvc
 }
+
 func (c *HttpClient) InsurancePlans() InsurancePlanServicer {
 	return c.InsurancePlanSvc
 }
+
 func (c *HttpClient) Letters() LetterServicer {
 	return c.LetterSvc
 }
+
 func (c *HttpClient) Medications() MedicationServicer {
 	return c.MedicationSvc
 }
+
 func (c *HttpClient) MessageThreads() MessageThreadServicer {
 	return c.MessageThreadSvc
 }
+
 func (c *HttpClient) NonVisitNotes() NonVisitNoteServicer {
 	return c.NonVisitNoteSvc
 }
+
 func (c *HttpClient) Patients() PatientServicer {
 	return c.PatientSvc
 }
+
 func (c *HttpClient) Physicians() PhysicianServicer {
 	return c.PhysicianSvc
 }
+
 func (c *HttpClient) Practices() PracticeServicer {
 	return c.PracticeSvc
 }
+
 func (c *HttpClient) PrescriptionFills() PrescriptionFillServicer {
 	return c.PrescriptionFillSvc
 }
+
 func (c *HttpClient) Problems() ProblemServicer {
 	return c.ProblemSvc
 }
+
 func (c *HttpClient) RecurringEventGroups() RecurringEventGroupServicer {
 	return c.RecurringEventGroupService
 }
+
 func (c *HttpClient) ServiceLocations() ServiceLocationServicer {
 	return c.ServiceLocationSvc
 }
+
 func (c *HttpClient) Subscriptions() SubscriptionServicer {
 	return c.SubscriptionSvc
 }
+
 func (c *HttpClient) ThreadMembers() ThreadMemberServicer {
 	return c.ThreadMemberSvc
 }

--- a/client.go
+++ b/client.go
@@ -31,7 +31,31 @@ const (
 	WebhookEventActionDeleted string = "deleted"
 )
 
-type Client struct {
+type Client interface {
+	Appointments() AppointmentServicer
+	ClinicalDocuments() ClinicalDocumentServicer
+	Contacts() ContactServicer
+	DiscontinuedMedications() DiscontinuedMedicationServicer
+	HistoryDownloadFills() HistoryDownloadFillServicer
+	InsuranceCompanies() InsuranceCompanyServicer
+	InsuranceEligibility() InsuranceEligibilityServicer
+	InsurancePlans() InsurancePlanServicer
+	Letters() LetterServicer
+	Medications() MedicationServicer
+	MessageThreads() MessageThreadServicer
+	NonVisitNotes() NonVisitNoteServicer
+	Patients() PatientServicer
+	Physicians() PhysicianServicer
+	Practices() PracticeServicer
+	PrescriptionFills() PrescriptionFillServicer
+	Problems() ProblemServicer
+	RecurringEventGroups() RecurringEventGroupServicer
+	ServiceLocations() ServiceLocationServicer
+	Subscriptions() SubscriptionServicer
+	ThreadMembers() ThreadMemberServicer
+}
+
+type HttpClient struct {
 	httpClient *http.Client
 	baseURL    string
 	tracer     trace.Tracer
@@ -59,7 +83,9 @@ type Client struct {
 	ThreadMemberSvc            *ThreadMemberService
 }
 
-func NewClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseURL string) *Client {
+var _ Client = (*HttpClient)(nil)
+
+func NewHttpClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseURL string) *HttpClient {
 	config := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -68,7 +94,7 @@ func NewClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseUR
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
 
-	client := &Client{
+	client := &HttpClient{
 		httpClient: config.Client(ctx),
 		baseURL:    baseURL,
 		tracer:     otel.GetTracerProvider().Tracer("github.com/authorhealth/go-elation"),
@@ -97,6 +123,70 @@ func NewClient(httpClient *http.Client, tokenURL, clientID, clientSecret, baseUR
 	client.ThreadMemberSvc = &ThreadMemberService{client}
 
 	return client
+}
+
+func (c *HttpClient) Appointments() AppointmentServicer {
+	return c.AppointmentSvc
+}
+func (c *HttpClient) ClinicalDocuments() ClinicalDocumentServicer {
+	return c.ClinicalDocumentSvc
+}
+func (c *HttpClient) Contacts() ContactServicer {
+	return c.ContactSvc
+}
+func (c *HttpClient) DiscontinuedMedications() DiscontinuedMedicationServicer {
+	return c.DiscontinuedMedicationSvc
+}
+func (c *HttpClient) HistoryDownloadFills() HistoryDownloadFillServicer {
+	return c.HistoryDownloadFillSvc
+}
+func (c *HttpClient) InsuranceCompanies() InsuranceCompanyServicer {
+	return c.InsuranceCompanySvc
+}
+func (c *HttpClient) InsuranceEligibility() InsuranceEligibilityServicer {
+	return c.InsuranceEligibilitySvc
+}
+func (c *HttpClient) InsurancePlans() InsurancePlanServicer {
+	return c.InsurancePlanSvc
+}
+func (c *HttpClient) Letters() LetterServicer {
+	return c.LetterSvc
+}
+func (c *HttpClient) Medications() MedicationServicer {
+	return c.MedicationSvc
+}
+func (c *HttpClient) MessageThreads() MessageThreadServicer {
+	return c.MessageThreadSvc
+}
+func (c *HttpClient) NonVisitNotes() NonVisitNoteServicer {
+	return c.NonVisitNoteSvc
+}
+func (c *HttpClient) Patients() PatientServicer {
+	return c.PatientSvc
+}
+func (c *HttpClient) Physicians() PhysicianServicer {
+	return c.PhysicianSvc
+}
+func (c *HttpClient) Practices() PracticeServicer {
+	return c.PracticeSvc
+}
+func (c *HttpClient) PrescriptionFills() PrescriptionFillServicer {
+	return c.PrescriptionFillSvc
+}
+func (c *HttpClient) Problems() ProblemServicer {
+	return c.ProblemSvc
+}
+func (c *HttpClient) RecurringEventGroups() RecurringEventGroupServicer {
+	return c.RecurringEventGroupService
+}
+func (c *HttpClient) ServiceLocations() ServiceLocationServicer {
+	return c.ServiceLocationSvc
+}
+func (c *HttpClient) Subscriptions() SubscriptionServicer {
+	return c.SubscriptionSvc
+}
+func (c *HttpClient) ThreadMembers() ThreadMemberServicer {
+	return c.ThreadMemberSvc
 }
 
 type Response[ResultsT any] struct {
@@ -149,7 +239,7 @@ func (e Error) Error() string {
 	return fmt.Sprintf("API error (status code %d)", e.StatusCode)
 }
 
-func (c *Client) request(ctx context.Context, method string, path string, query any, body any, out any) (*http.Response, error) {
+func (c *HttpClient) request(ctx context.Context, method string, path string, query any, body any, out any) (*http.Response, error) {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(semconv.HTTPRequestMethodKey.String(method))
 

--- a/clinical_document.go
+++ b/clinical_document.go
@@ -20,7 +20,7 @@ type ClinicalDocumentServicer interface {
 var _ ClinicalDocumentServicer = (*ClinicalDocumentService)(nil)
 
 type ClinicalDocumentService struct {
-	client *Client
+	client *HttpClient
 }
 
 type ClinicalDocument struct {

--- a/clinical_document_test.go
+++ b/clinical_document_test.go
@@ -53,7 +53,7 @@ func TestClinicalDocumentService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ClinicalDocumentService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestClinicalDocumentService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ClinicalDocumentService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/contact.go
+++ b/contact.go
@@ -20,7 +20,7 @@ type ContactServicer interface {
 var _ ContactServicer = (*ContactService)(nil)
 
 type ContactService struct {
-	client *Client
+	client *HttpClient
 }
 
 type Contact struct {

--- a/contact_test.go
+++ b/contact_test.go
@@ -53,7 +53,7 @@ func TestContactService_List(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ContactService{client}
 
 	found, res, err := svc.List(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestContactService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ContactService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/discontinued_medication.go
+++ b/discontinued_medication.go
@@ -22,7 +22,7 @@ type DiscontinuedMedicationServicer interface {
 var _ DiscontinuedMedicationServicer = (*DiscontinuedMedicationService)(nil)
 
 type DiscontinuedMedicationService struct {
-	client *Client
+	client *HttpClient
 }
 
 type DiscontinuedMedicationCreate struct {

--- a/discontinued_medication_test.go
+++ b/discontinued_medication_test.go
@@ -62,7 +62,7 @@ func TestDiscontinuedMedicationService_Create(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 			svc := DiscontinuedMedicationService{client}
 
 			created, res, err := svc.Create(context.Background(), testCase.create)
@@ -136,7 +136,7 @@ func TestDiscontinuedMedicationService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := DiscontinuedMedicationService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -169,7 +169,7 @@ func TestDiscontinuedMedicationService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := DiscontinuedMedicationService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -214,7 +214,7 @@ func TestDiscontinuedMedicationService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := DiscontinuedMedicationService{client}
 
 	updated, res, err := svc.Update(context.Background(), id, expected)

--- a/history_download_fill.go
+++ b/history_download_fill.go
@@ -20,7 +20,7 @@ type HistoryDownloadFillServicer interface {
 var _ HistoryDownloadFillServicer = (*HistoryDownloadFillService)(nil)
 
 type HistoryDownloadFillService struct {
-	client *Client
+	client *HttpClient
 }
 
 type HistoryDownloadFill struct {

--- a/history_download_fill_test.go
+++ b/history_download_fill_test.go
@@ -53,7 +53,7 @@ func TestHistoryDownloadFillService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := HistoryDownloadFillService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestHistoryDownloadFillService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := HistoryDownloadFillService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/insurance_company.go
+++ b/insurance_company.go
@@ -22,7 +22,7 @@ type InsuranceCompanyServicer interface {
 var _ InsuranceCompanyServicer = (*InsuranceCompanyService)(nil)
 
 type InsuranceCompanyService struct {
-	client *Client
+	client *HttpClient
 }
 
 type InsuranceCompanyCreate struct {

--- a/insurance_company_test.go
+++ b/insurance_company_test.go
@@ -71,7 +71,7 @@ func TestInsuranceCompanyService_Create(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 			svc := InsuranceCompanyService{client}
 
 			created, res, err := svc.Create(context.Background(), testCase.create)
@@ -133,7 +133,7 @@ func TestInsuranceCompanyService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceCompanyService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -166,7 +166,7 @@ func TestInsuranceCompanyService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceCompanyService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -221,7 +221,7 @@ func TestInsuranceCompanyService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceCompanyService{client}
 
 	updated, res, err := svc.Update(context.Background(), id, expected)
@@ -245,7 +245,7 @@ func TestInsuranceCompanyService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceCompanyService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/insurance_eligibility.go
+++ b/insurance_eligibility.go
@@ -20,7 +20,7 @@ type InsuranceEligibilityServicer interface {
 var _ InsuranceEligibilityServicer = (*InsuranceEligibilityService)(nil)
 
 type InsuranceEligibilityService struct {
-	client *Client
+	client *HttpClient
 }
 
 type InsuranceEligibilityCreate struct {

--- a/insurance_eligibility_test.go
+++ b/insurance_eligibility_test.go
@@ -58,7 +58,7 @@ func TestInsuranceEligibilityService_Create(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 			svc := InsuranceEligibilityService{client}
 
 			created, res, err := svc.Create(context.Background(), id, testCase.create)
@@ -91,7 +91,7 @@ func TestInsuranceEligibilityService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceEligibilityService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -122,7 +122,7 @@ func TestInsuranceEligibilityService_GetFullReport(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsuranceEligibilityService{client}
 
 	found, res, err := svc.GetFullReport(context.Background(), id)

--- a/insurance_plan.go
+++ b/insurance_plan.go
@@ -22,7 +22,7 @@ type InsurancePlanServicer interface {
 var _ InsurancePlanServicer = (*InsurancePlanService)(nil)
 
 type InsurancePlanService struct {
-	client *Client
+	client *HttpClient
 }
 
 type InsurancePlanCreate struct {

--- a/insurance_plan_test.go
+++ b/insurance_plan_test.go
@@ -47,7 +47,7 @@ func TestInsurancePlanService_Create(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsurancePlanService{client}
 
 	created, res, err := svc.Create(context.Background(), expectedCreate)
@@ -107,7 +107,7 @@ func TestInsurancePlanService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsurancePlanService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -140,7 +140,7 @@ func TestInsurancePlanService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsurancePlanService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -183,7 +183,7 @@ func TestInsurancePlanService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsurancePlanService{client}
 
 	updated, res, err := svc.Update(context.Background(), id, expected)
@@ -207,7 +207,7 @@ func TestInsurancePlanService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := InsurancePlanService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/letter.go
+++ b/letter.go
@@ -20,7 +20,7 @@ type LetterServicer interface {
 var _ LetterServicer = (*LetterService)(nil)
 
 type LetterService struct {
-	client *Client
+	client *HttpClient
 }
 
 type Letter struct {

--- a/letter_test.go
+++ b/letter_test.go
@@ -53,7 +53,7 @@ func TestLetterService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := LetterService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestLetterService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := LetterService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/medication.go
+++ b/medication.go
@@ -21,7 +21,7 @@ type MedicationServicer interface {
 var _ MedicationServicer = (*MedicationService)(nil)
 
 type MedicationService struct {
-	client *Client
+	client *HttpClient
 }
 
 type PatientMedication struct {

--- a/medication_test.go
+++ b/medication_test.go
@@ -84,7 +84,7 @@ func TestMedicationService_Create(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 			svc := MedicationService{client}
 
 			created, res, err := svc.Create(context.Background(), testCase.create)
@@ -165,7 +165,7 @@ func TestMedicationService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := MedicationService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -198,7 +198,7 @@ func TestMedicationService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := MedicationService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/message_thread.go
+++ b/message_thread.go
@@ -20,7 +20,7 @@ type MessageThreadServicer interface {
 var _ MessageThreadServicer = (*MessageThreadService)(nil)
 
 type MessageThreadService struct {
-	client *Client
+	client *HttpClient
 }
 
 type MessageThread struct {

--- a/message_thread_test.go
+++ b/message_thread_test.go
@@ -53,7 +53,7 @@ func TestMessageThreadService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := MessageThreadService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestMessageThreadService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := MessageThreadService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/non_visit_note.go
+++ b/non_visit_note.go
@@ -20,7 +20,7 @@ type NonVisitNoteServicer interface {
 var _ NonVisitNoteServicer = (*NonVisitNoteService)(nil)
 
 type NonVisitNoteService struct {
-	client *Client
+	client *HttpClient
 }
 
 type NonVisitNote struct {

--- a/non_visit_note_test.go
+++ b/non_visit_note_test.go
@@ -53,7 +53,7 @@ func TestNonVisitNoteService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := NonVisitNoteService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestNonVisitNoteService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := NonVisitNoteService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/patient.go
+++ b/patient.go
@@ -23,7 +23,7 @@ type PatientServicer interface {
 var _ PatientServicer = (*PatientService)(nil)
 
 type PatientService struct {
-	client *Client
+	client *HttpClient
 }
 
 type PatientCreate struct {

--- a/patient_test.go
+++ b/patient_test.go
@@ -93,7 +93,7 @@ func TestPatientService_Create(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 			svc := PatientService{client}
 
 			created, res, err := svc.Create(context.Background(), testCase.create)
@@ -191,7 +191,7 @@ func TestPatientService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PatientService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -224,7 +224,7 @@ func TestPatientService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PatientService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -311,7 +311,7 @@ func TestPatientService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PatientService{client}
 
 	updated, res, err := svc.Update(context.Background(), id, expected)
@@ -335,7 +335,7 @@ func TestPatientService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PatientService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/physician.go
+++ b/physician.go
@@ -19,7 +19,7 @@ type PhysicianServicer interface {
 var _ PhysicianServicer = (*PhysicianService)(nil)
 
 type PhysicianService struct {
-	client *Client
+	client *HttpClient
 }
 
 type Physician struct {

--- a/physician_test.go
+++ b/physician_test.go
@@ -65,7 +65,7 @@ func TestPhysicianService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PhysicianService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -98,7 +98,7 @@ func TestPhysicianService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PhysicianService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/practice.go
+++ b/practice.go
@@ -20,7 +20,7 @@ type PracticeServicer interface {
 var _ PracticeServicer = (*PracticeService)(nil)
 
 type PracticeService struct {
-	client *Client
+	client *HttpClient
 }
 
 type Practice struct {

--- a/practice_test.go
+++ b/practice_test.go
@@ -53,7 +53,7 @@ func TestPracticeService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PracticeService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestPracticeService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PracticeService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/prescription_fill.go
+++ b/prescription_fill.go
@@ -21,7 +21,7 @@ type PrescriptionFillServicer interface {
 var _ PrescriptionFillServicer = (*PrescriptionFillService)(nil)
 
 type PrescriptionFillService struct {
-	client *Client
+	client *HttpClient
 }
 
 type PrescriptionFill struct {

--- a/prescription_fill_test.go
+++ b/prescription_fill_test.go
@@ -53,7 +53,7 @@ func TestPrescriptionFillService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PrescriptionFillService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestPrescriptionFillService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := PrescriptionFillService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/problem.go
+++ b/problem.go
@@ -20,7 +20,7 @@ type ProblemServicer interface {
 var _ ProblemServicer = (*ProblemService)(nil)
 
 type ProblemService struct {
-	client *Client
+	client *HttpClient
 }
 
 type PatientProblem struct {

--- a/problem_test.go
+++ b/problem_test.go
@@ -57,7 +57,7 @@ func TestProblemService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ProblemService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -90,7 +90,7 @@ func TestProblemService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ProblemService{client}
 
 	found, res, err := svc.Get(context.Background(), id)

--- a/recurring_event_group.go
+++ b/recurring_event_group.go
@@ -23,7 +23,7 @@ type RecurringEventGroupServicer interface {
 var _ RecurringEventGroupServicer = (*RecurringEventGroupService)(nil)
 
 type RecurringEventGroupService struct {
-	client *Client
+	client *HttpClient
 }
 
 type RecurringEventGroupSchedule struct {

--- a/recurring_event_group_test.go
+++ b/recurring_event_group_test.go
@@ -68,7 +68,7 @@ func TestRecurringEventGroupService_Create(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	created, res, err := svc.Create(context.Background(), expected)
@@ -140,7 +140,7 @@ func TestRecurringEventGroupService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -212,7 +212,7 @@ func TestRecurringEventGroupService_Find_Multiple_Params(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -245,7 +245,7 @@ func TestRecurringEventGroupService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	found, res, err := svc.Get(context.Background(), id)
@@ -308,7 +308,7 @@ func TestRecurringEventGroupService_Update(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	found, res, err := svc.Update(context.Background(), id, expected)
@@ -332,7 +332,7 @@ func TestRecurringEventGroupService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := RecurringEventGroupService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/service_location.go
+++ b/service_location.go
@@ -17,7 +17,7 @@ type ServiceLocationServicer interface {
 var _ ServiceLocationServicer = (*ServiceLocationService)(nil)
 
 type ServiceLocationService struct {
-	client *Client
+	client *HttpClient
 }
 
 type ServiceLocation struct {

--- a/service_location_test.go
+++ b/service_location_test.go
@@ -52,7 +52,7 @@ func TestServiceLocationService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ServiceLocationService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)

--- a/subscription.go
+++ b/subscription.go
@@ -23,7 +23,7 @@ type SubscriptionServicer interface {
 var _ SubscriptionServicer = (*SubscriptionService)(nil)
 
 type SubscriptionService struct {
-	client *Client
+	client *HttpClient
 }
 
 type Subscription struct {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -44,7 +44,7 @@ func TestSubscriptionService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := SubscriptionService{client}
 
 	found, res, err := svc.Find(context.Background())
@@ -90,7 +90,7 @@ func TestSubscriptionService_Subscribe(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := SubscriptionService{client}
 
 	found, res, err := svc.Subscribe(context.Background(), expected)
@@ -114,7 +114,7 @@ func TestSubscriptionService_Delete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := SubscriptionService{client}
 
 	res, err := svc.Delete(context.Background(), id)

--- a/thread_member.go
+++ b/thread_member.go
@@ -20,7 +20,7 @@ type ThreadMemberServicer interface {
 var _ ThreadMemberServicer = (*ThreadMemberService)(nil)
 
 type ThreadMemberService struct {
-	client *Client
+	client *HttpClient
 }
 
 type ThreadMember struct {

--- a/thread_member_test.go
+++ b/thread_member_test.go
@@ -53,7 +53,7 @@ func TestThreadMemberService_Find(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ThreadMemberService{client}
 
 	found, res, err := svc.Find(context.Background(), opts)
@@ -86,7 +86,7 @@ func TestThreadMemberService_Get(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	client := NewHttpClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
 	svc := ThreadMemberService{client}
 
 	found, res, err := svc.Get(context.Background(), id)


### PR DESCRIPTION
This PR splits the `Client` struct into an interface (`Client`) and implementation (`HttpClient`). This helps consumers of the client to write tests by allowing test doubles to be written for both the entire client and the individual services.