### PR TITLE
[CM-392] - Update elation client to support writing Visit Note and Bill

### DIFF
--- a/bill.go
+++ b/bill.go
@@ -1,0 +1,119 @@
+package elation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type BillServicer interface {
+	Create(ctx context.Context, create *BillCreate) (*Bill, *http.Response, error)
+}
+
+var _ BillServicer = (*BillService)(nil)
+
+type BillService struct {
+	client *HTTPClient
+}
+
+type Bill struct {
+	ID                   int64                `json:"id"`                      //: 65099661468,
+	RefNumber            *string              `json:"ref_number"`              //: null,                        // string(50). required for PATCH that marks bill as processed.
+	ServiceDate          time.Time            `json:"service_date"`            //: "2016-10-12T12:00:00Z",
+	BillingDate          *time.Time           `json:"billing_date"`            //: null,                        // datetime(iso8601). required for PATCH that marks bill as processed.
+	BillingStatus        string               `json:"billing_status"`          //: "Unbilled",
+	BillingError         *string              `json:"billing_error"`           //: null,                        // string(200). required for PATCH that marks bill as failed.
+	BillingRawError      *string              `json:"billing_raw_error"`       //: null,                        // longtext. optional for PATCH that marks bill as failed.
+	Notes                string               `json:"notes"`                   //: "patient has not paid yet",
+	CPTs                 []*BillCPT           `json:"cpts"`                    //: [{}],
+	Payment              *BillPayment         `json:"payment"`                 //: {},
+	VisitNoteID          int64                `json:"visit_note_id"`           //: 64409108504,
+	VisitNoteSignedDate  time.Time            `json:"visit_note_signed_date"`  //: "2016-10-12T22:11:01Z",
+	VisitNoteDeletedDate *time.Time           `json:"visit_note_deleted_date"` //: null,
+	ReferringProvider    *BillProvider        `json:"referring_provider"`      //: {},
+	BillingProvider      int64                `json:"billing_provider"`        //: 42120898,
+	RenderingProvider    int64                `json:"rendering_provider"`      //: 68382673,
+	SupervisingProvider  int64                `json:"supervising_provider"`    //: 52893234,
+	OrderingProvider     *BillProvider        `json:"ordering_provider"`       //: {}
+	ServiceLocation      *BillServiceLocation `json:"service_location"`        //: {}
+	Physician            int64                `json:"physician"`               //: 64811630594,
+	Practice             int64                `json:"practice"`                //: 65540,
+	Patient              int64                `json:"patient"`                 //: 64901939201,
+	PriorAuthorization   string               `json:"prior_authorization"`     //: "1234-ABC",
+	Metadata             any                  `json:"metadata"`                //: null,
+	CreatedDate          time.Time            `json:"created_date"`            //: "2016-05-23T17:50:50Z",
+	LastModifiedDate     time.Time            `json:"last_modified_date"`      //: "2016-10-12T22:39:46Z"
+}
+
+type BillCreate struct {
+	ServiceLocation     *BillServiceLocation `json:"service_location"`     //: {}           // required
+	VisitNoteID         int64                `json:"visit_note_id"`        //: 64409108504, // required
+	Patient             int64                `json:"patient"`              //: 64901939201, // required
+	Practice            int64                `json:"practice"`             //: 65540, 		  // required
+	Physician           int64                `json:"physician"`            //: 64811630594, // required
+	CPTs                []*BillCPT           `json:"cpts"`                 //: [{}],
+	BillingProvider     int64                `json:"billing_provider"`     //: 42120898,
+	RenderingProvider   int64                `json:"rendering_provider"`   //: 68382673,
+	SupervisingProvider int64                `json:"supervising_provider"` //: 52893234,
+	ReferringProvider   *BillProvider        `json:"referring_provider"`   //: {},
+	OrderingProvider    *BillProvider        `json:"ordering_provider"`    //: {},
+	PriorAuthorization  string               `json:"prior_authorization"`  //: "1234-ABC",
+	PaymentAmount       float64              `json:"payment_amount"`       //: 10.00,
+	Notes               string               `json:"notes"`                //: "patient has not paid yet",
+}
+
+type BillCPT struct {
+	CPT        int64    `json:"cpt"`         //: "99213",
+	Modifiers  []string `json:"modifiers"`   //: ["10"],
+	DXs        []string `json:"dxs"`         //: ["D23.4"],
+	AltDXs     []string `json:"alt_dxs"`     //: ["216.4"],
+	UnitCharge any      `json:"unit_charge"` //: null,
+	Units      any      `json:"units"`       //: null
+}
+
+type BillPayment struct {
+	Amount        string    `json:"amount"`         //: "10.00",
+	WhenCollected time.Time `json:"when_collected"` //: "2016-10-12T22:11:01Z"
+}
+
+type BillProvider struct {
+	Name  string `json:"name"`  //: "Beverly Crusher, MD (555-555-5555)",
+	State string `json:"state"` //: "CA",
+	NPI   string `json:"npi"`   //: "1701170117"
+}
+
+type BillServiceLocation struct {
+	ID                 int64      `json:"id"`                    //: 13631735,
+	Name               string     `json:"name"`                  //: "Elation North",
+	IsPrimary          bool       `json:"is_primary"`            //: true,
+	PlaceOfService     string     `json:"place_of_service"`      //: "Office",
+	PlaceOfServiceCode string     `json:"place_of_service_code"` //: "11",
+	AddressLine1       string     `json:"address_line1"`         //: "1234 First Practice Way",
+	AddressLine2       string     `json:"address_line2"`         //: "",
+	City               string     `json:"city"`                  //: "San Francisco",
+	State              string     `json:"state"`                 //: "CA",
+	Zip                string     `json:"zip"`                   //: "94114",
+	Phone              string     `json:"phone"`                 //: "",
+	CreatedDate        time.Time  `json:"created_date"`          //: "2017-08-28T22:46:14.445876Z",
+	DeletedDate        *time.Time `json:"deleted_date"`          //: null
+}
+
+func (b *BillService) Create(ctx context.Context, create *BillCreate) (*Bill, *http.Response, error) {
+	ctx, span := b.client.tracer.Start(ctx, "create bill", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	bill := &Bill{}
+
+	res, err := b.client.request(ctx, http.MethodPost, "/bills", nil, create, &bill)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return bill, res, nil
+}

--- a/bill_test.go
+++ b/bill_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,29 +18,68 @@ func TestBillService_Create(t *testing.T) {
 	}{
 		"required fields only request": {
 			create: &BillCreate{
-				ServiceLocation: &BillServiceLocation{},
-				VisitNoteID:     64409108504,
-				Patient:         64901939201,
-				Practice:        65540,
-				Physician:       64811630594,
+				ServiceLocation: &BillServiceLocation{
+					ID:                 1,
+					Name:               "service location",
+					IsPrimary:          true,
+					PlaceOfService:     "office",
+					PlaceOfServiceCode: "11",
+					AddressLine1:       "123 Main St",
+					City:               "Schenectady",
+					State:              "NY",
+					Zip:                "12345",
+					Phone:              "555-234-5678",
+					CreatedDate:        time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				},
+				VisitNoteID: 64409108504,
+				Patient:     64901939201,
+				Practice:    65540,
+				Physician:   64811630594,
 			},
 		},
 		"all specified fields request": {
 			create: &BillCreate{
-				ServiceLocation:     &BillServiceLocation{},
-				VisitNoteID:         64409108504,
-				Patient:             64901939201,
-				Practice:            65540,
-				Physician:           64811630594,
-				CPTs:                []*BillCPT{},
+				ServiceLocation: &BillServiceLocation{
+					ID:                 1,
+					Name:               "service location",
+					IsPrimary:          true,
+					PlaceOfService:     "office",
+					PlaceOfServiceCode: "11",
+					AddressLine1:       "123 Main St",
+					City:               "Schenectady",
+					State:              "NY",
+					Zip:                "12345",
+					Phone:              "555-234-5678",
+					CreatedDate:        time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				},
+				VisitNoteID: 64409108504,
+				Patient:     64901939201,
+				Practice:    65540,
+				Physician:   64811630594,
+				CPTs: []*BillCPT{
+					{
+						CPT:       12,
+						Modifiers: []string{"modifier 1", "modifier 2"},
+						DXs:       []string{"dx 1", "dx 2"},
+						AltDXs:    []string{"alt dx 1", "alt dx 2"},
+					},
+				},
 				BillingProvider:     42120898,
 				RenderingProvider:   68382673,
 				SupervisingProvider: 52893234,
-				ReferringProvider:   &BillProvider{},
-				OrderingProvider:    &BillProvider{},
-				PriorAuthorization:  "1234-ABC",
-				PaymentAmount:       100.00,
-				Notes:               "additional billing notes",
+				ReferringProvider: &BillProvider{
+					Name:  "referring provider",
+					State: "NY",
+					NPI:   "1234567890",
+				},
+				OrderingProvider: &BillProvider{
+					Name:  "referring provider",
+					State: "NY",
+					NPI:   "1234567890",
+				},
+				PriorAuthorization: "1234-ABC",
+				PaymentAmount:      100.00,
+				Notes:              "additional billing notes",
 			},
 		},
 	}

--- a/bill_test.go
+++ b/bill_test.go
@@ -7,38 +7,39 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVisitNoteService_Create(t *testing.T) {
+func TestBillService_Create(t *testing.T) {
 	testCases := map[string]struct {
-		create *VisitNoteCreate
+		create *BillCreate
 	}{
 		"required fields only request": {
-			create: &VisitNoteCreate{
-				Bullets:      []*VisitNoteBullet{},
-				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				Patient:      12345,
-				Template:     "SOAP",
-				Physician:    12345,
+			create: &BillCreate{
+				ServiceLocation: &BillServiceLocation{},
+				VisitNoteID:     64409108504,
+				Patient:         64901939201,
+				Practice:        65540,
+				Physician:       64811630594,
 			},
 		},
 		"all specified fields request": {
-			create: &VisitNoteCreate{
-				Bullets:      []*VisitNoteBullet{},
-				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				Patient:      12345,
-				Template:     "SOAP",
-				Physician:    12345,
-				Type:         "Office Visit Note",
-				Confidential: true,
-				SignedBy:     12345,
-				SignedDate:   time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				Signatures:   []*VisitNoteSignature{},
+			create: &BillCreate{
+				ServiceLocation:     &BillServiceLocation{},
+				VisitNoteID:         64409108504,
+				Patient:             64901939201,
+				Practice:            65540,
+				Physician:           64811630594,
+				CPTs:                []*BillCPT{},
+				BillingProvider:     42120898,
+				RenderingProvider:   68382673,
+				SupervisingProvider: 52893234,
+				ReferringProvider:   &BillProvider{},
+				OrderingProvider:    &BillProvider{},
+				PriorAuthorization:  "1234-ABC",
+				PaymentAmount:       100.00,
+				Notes:               "additional billing notes",
 			},
 		},
 	}
@@ -52,18 +53,18 @@ func TestVisitNoteService_Create(t *testing.T) {
 				}
 
 				assert.Equal(http.MethodPost, r.Method)
-				assert.Equal("/visit_notes", r.URL.Path)
+				assert.Equal("/bills", r.URL.Path)
 
 				body, err := io.ReadAll(r.Body)
 				assert.NoError(err)
 
-				create := &VisitNoteCreate{}
+				create := &BillCreate{}
 				err = json.Unmarshal(body, create)
 				assert.NoError(err)
 
 				assert.Equal(testCase.create, create)
 
-				b, err := json.Marshal(&VisitNote{})
+				b, err := json.Marshal(&Bill{})
 				assert.NoError(err)
 
 				w.Header().Set("Content-Type", "application/json")
@@ -73,7 +74,7 @@ func TestVisitNoteService_Create(t *testing.T) {
 			defer srv.Close()
 
 			client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
-			svc := VisitNoteService{client}
+			svc := BillService{client}
 
 			created, res, err := svc.Create(context.Background(), testCase.create)
 			assert.NotNil(created)

--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ const (
 
 type Client interface {
 	Appointments() AppointmentServicer
+	Bill() BillServicer
 	ClinicalDocuments() ClinicalDocumentServicer
 	Contacts() ContactServicer
 	DiscontinuedMedications() DiscontinuedMedicationServicer
@@ -62,6 +63,7 @@ type HTTPClient struct {
 	tracer     trace.Tracer
 
 	AppointmentSvc             *AppointmentService
+	BillSvc                    *BillService
 	ClinicalDocumentSvc        *ClinicalDocumentService
 	ContactSvc                 *ContactService
 	DiscontinuedMedicationSvc  *DiscontinuedMedicationService
@@ -103,6 +105,7 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 	}
 
 	client.AppointmentSvc = &AppointmentService{client}
+	client.BillSvc = &BillService{client}
 	client.ClinicalDocumentSvc = &ClinicalDocumentService{client}
 	client.ContactSvc = &ContactService{client}
 	client.DiscontinuedMedicationSvc = &DiscontinuedMedicationService{client}
@@ -130,6 +133,10 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 
 func (c *HTTPClient) Appointments() AppointmentServicer {
 	return c.AppointmentSvc
+}
+
+func (c *HTTPClient) Bill() BillServicer {
+	return c.BillSvc
 }
 
 func (c *HTTPClient) ClinicalDocuments() ClinicalDocumentServicer {

--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type Client interface {
 	ServiceLocations() ServiceLocationServicer
 	Subscriptions() SubscriptionServicer
 	ThreadMembers() ThreadMemberServicer
+	VisitNote() VisitNoteServicer
 }
 
 type HTTPClient struct {
@@ -81,6 +82,7 @@ type HTTPClient struct {
 	ServiceLocationSvc         *ServiceLocationService
 	SubscriptionSvc            *SubscriptionService
 	ThreadMemberSvc            *ThreadMemberService
+	VisitNoteSvc               *VisitNoteService
 }
 
 var _ Client = (*HTTPClient)(nil)
@@ -121,6 +123,7 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 	client.ServiceLocationSvc = &ServiceLocationService{client}
 	client.SubscriptionSvc = &SubscriptionService{client}
 	client.ThreadMemberSvc = &ThreadMemberService{client}
+	client.VisitNoteSvc = &VisitNoteService{client}
 
 	return client
 }
@@ -207,6 +210,10 @@ func (c *HTTPClient) Subscriptions() SubscriptionServicer {
 
 func (c *HTTPClient) ThreadMembers() ThreadMemberServicer {
 	return c.ThreadMemberSvc
+}
+
+func (c *HTTPClient) VisitNote() VisitNoteServicer {
+	return c.VisitNoteSvc
 }
 
 type Response[ResultsT any] struct {

--- a/visit_note.go
+++ b/visit_note.go
@@ -27,7 +27,7 @@ type VisitNote struct {
 	Edits               []*VisitNoteEdit      `json:"edits"`                 //: [{}],
 	Signatures          []*VisitNoteSignature `json:"signatures"`            //: [{}],
 	Type                string                `json:"type"`                  //: "Office Visit Note",              // string(50).  This list is managed in the practice"s setting page
-	Template            string                `json:"template"`              //: "SOAP",
+	Template            string                `json:"template"`              //: "SOAP", ["Simple", "SOAP", "Complete H&P (1 col)", "Complete H&P (2 col)", "Complete H&P (2 col A/P)", "Pre-Op"]
 	AmendmentRequest    any                   `json:"amendment_request"`     //: null,
 	Patient             int64                 `json:"patient"`               //: 1638401,
 	Physician           int64                 `json:"physician"`             //: 131074,
@@ -46,11 +46,11 @@ type VisitNote struct {
 }
 
 type VisitNoteCreate struct {
-	Bullets      []*VisitNoteBullet    `json:"bullets"`       //: [{}], 				            // Required
-	ChartDate    time.Time             `json:"chart_date"`    //: "2010-06-10T11:05:08Z", 	// Required
-	DocumentDate time.Time             `json:"document_date"` //: "2010-06-10T11:05:08Z", 	// Required
-	Patient      int64                 `json:"patient"`       //: 1638401, 				          // Required
-	Template     string                `json:"template"`      //: "SOAP", 				          // Required
+	Bullets      []*VisitNoteBullet    `json:"bullets"`       //: [{}], 				                                                                                                     // Required
+	ChartDate    time.Time             `json:"chart_date"`    //: "2010-06-10T11:05:08Z", 	                                                                                         // Required
+	DocumentDate time.Time             `json:"document_date"` //: "2010-06-10T11:05:08Z", 	                                                                                         // Required
+	Patient      int64                 `json:"patient"`       //: 1638401, 				                                                                                                   // Required
+	Template     string                `json:"template"`      //: "SOAP", ["Simple", "SOAP", "Complete H&P (1 col)", "Complete H&P (2 col)", "Complete H&P (2 col A/P)", "Pre-Op"]   // Required
 	Physician    int64                 `json:"physician"`     //: 131074, 				          // Required
 	Type         string                `json:"type"`          //: "Office Visit Note",
 	Confidential bool                  `json:"confidential"`  //: false,
@@ -60,7 +60,7 @@ type VisitNoteCreate struct {
 }
 
 type VisitNoteBullet struct {
-	Category       string                 `json:"category"`         //: ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
+	Category       string                 `json:"category"`         //: "Problem", ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
 	Text           string                 `json:"text"`             //: "Dizziness" string(500),
 	Version        int64                  `json:"version"`          //: 1,
 	Sequence       int64                  `json:"sequence"`         //: 0,
@@ -77,8 +77,8 @@ type VisitNoteBullet struct {
 }
 
 type VisitNoteChild struct {
-	Category       string                 `json:"category"`         //: ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
-	Text           string                 `json:"text"`             //: "Dizziness" string(500),
+	Category       string                 `json:"category"`         //: "Problem", ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
+	Text           string                 `json:"text"`             //: "Dizziness", string(500),
 	Version        int64                  `json:"version"`          //: 1,
 	Sequence       int64                  `json:"sequence"`         //: 0,
 	Author         int64                  `json:"author"`           //: 10,

--- a/visit_note.go
+++ b/visit_note.go
@@ -1,0 +1,181 @@
+package elation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type VisitNoteServicer interface {
+	Create(ctx context.Context, create *VisitNoteCreate) (*VisitNote, *http.Response, error)
+}
+
+var _ VisitNoteServicer = (*VisitNoteService)(nil)
+
+type VisitNoteService struct {
+	client *HTTPClient
+}
+
+type VisitNote struct {
+	ID                  int64                 `json:"id"`
+	Bullets             []*VisitNoteBullet    `json:"bullets"`               //: [{}],
+	Checklists          *VisitNoteChecklists  `json:"checklists"`            //: {},
+	Edits               []*VisitNoteEdit      `json:"edits"`                 //: [{}],
+	Signatures          []*VisitNoteSignature `json:"signatures"`            //: [{}],
+	Type                string                `json:"type"`                  //: "Office Visit Note",              // string(50).  This list is managed in the practice"s setting page
+	Template            string                `json:"template"`              //: "SOAP",
+	AmendmentRequest    any                   `json:"amendment_request"`     //: null,
+	Patient             int64                 `json:"patient"`               //: 1638401,
+	Physician           int64                 `json:"physician"`             //: 131074,
+	Practice            int64                 `json:"practice"`              //: 34323,
+	DocumentDate        time.Time             `json:"document_date"`         //: "2010-06-10T11:05:08Z",
+	ChartDate           time.Time             `json:"chart_date"`            //: "2010-06-10T11:05:08Z",
+	ClinicalSummaryLink string                `json:"clinical_summary_link"` //: "http://localhost/api/2.0/visit_notes/140758496444440/clinical_summary",
+	VisitSummaryLink    string                `json:"visit_summary_link"`    //: "http://localhost/api/2.0/visit_notes/140758496444440/clinical_summary",
+	SignedDate          time.Time             `json:"signed_date"`           //: "2010-06-10T11:05:08Z",
+	SignedBy            int64                 `json:"signed_by"`             //: 131074,
+	CreatedDate         time.Time             `json:"created_date"`          //: "2010-06-10T11:05:08Z",
+	LastModified        time.Time             `json:"last_modified"`         //: "2022-05-20T11:06:12.507775Z",
+	DeletedDate         *time.Time            `json:"deleted_date"`          //: null,
+	Tags                []any                 `json:"tags"`                  //: [],
+	Confidential        bool                  `json:"confidential"`          //: false
+}
+
+type VisitNoteCreate struct {
+	Bullets      []*VisitNoteBullet    `json:"bullets"`       //: [{}], 				            // Required
+	ChartDate    time.Time             `json:"chart_date"`    //: "2010-06-10T11:05:08Z", 	// Required
+	DocumentDate time.Time             `json:"document_date"` //: "2010-06-10T11:05:08Z", 	// Required
+	Patient      int64                 `json:"patient"`       //: 1638401, 				          // Required
+	Template     string                `json:"template"`      //: "SOAP", 				          // Required
+	Physician    int64                 `json:"physician"`     //: 131074, 				          // Required
+	Type         string                `json:"type"`          //: "Office Visit Note",
+	Confidential bool                  `json:"confidential"`  //: false,
+	SignedBy     int64                 `json:"signed_by"`     //: 131074,
+	SignedDate   time.Time             `json:"signed_date"`   //: "2010-06-10T11:05:08Z",
+	Signatures   []*VisitNoteSignature `json:"signatures"`    //: [{}],
+}
+
+type VisitNoteBullet struct {
+	Category       string                 `json:"category"`         //: ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
+	Text           string                 `json:"text"`             //: "Dizziness" string(500),
+	Version        int64                  `json:"version"`          //: 1,
+	Sequence       int64                  `json:"sequence"`         //: 0,
+	Author         int64                  `json:"author"`           //: 10,
+	UpdatedDate    time.Time              `json:"updated_date"`     //: "2022-05-15T13:50:09"
+	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
+	ReplacedBy     any                    `json:"replaced_by"`      //: null,
+	Edit           any                    `json:"edit"`             //: null,
+	DeletedDate    *time.Time             `json:"deleted_date"`     //: null,
+	NoteDocument   *VisitNoteNoteDocument `json:"note_document"`    //: null,
+	NoteItem       *VisitNoteNoteItem     `json:"note_item"`        //: null,
+	Handout        *int64                 `json:"handout"`          //: null,
+	Children       []*VisitNoteChild      `json:"children"`         //: [{}]          // Not visible in the Find Visit Notes endpoint
+}
+
+type VisitNoteChild struct {
+	Category       string                 `json:"category"`         //: ["Problem", "Past", "Family", "Social", "Instr", "PE", "ROS", "Med", "Data", "Assessment", "Test", "Tx", "Narrative", "Followup", "Reason", "Plan", "Objective", "Hpi", "Allergies", "Habits", "Assessplan", "Consultant", "Attending", "Dateprocedure", "Surgical", "Orders", "Referenced", "Procedure"],
+	Text           string                 `json:"text"`             //: "Dizziness" string(500),
+	Version        int64                  `json:"version"`          //: 1,
+	Sequence       int64                  `json:"sequence"`         //: 0,
+	Author         int64                  `json:"author"`           //: 10,
+	UpdatedDate    time.Time              `json:"updated_date"`     //: "2022-05-15T13:50:09"
+	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
+	ReplacedBy     any                    `json:"replaced_by"`      //: null,
+	Edit           any                    `json:"edit"`             //: null,
+	DeletedDate    *time.Time             `json:"deleted_date"`     //: null,
+	NoteItem       *VisitNoteNoteItem     `json:"note_item"`        //: null,
+	NoteDocument   *VisitNoteNoteDocument `json:"note_document"`    //: null,
+	Handout        int64                  `json:"handout"`          //: 140758529736869
+}
+
+type VisitNoteNoteItem struct {
+	ID   int64          `json:"id"`   //: 338362508,
+	Item *VisitNoteItem `json:"item"` //: {}
+}
+
+type VisitNoteItem struct {
+	ID             int64      `json:"id"`              //: 240582699
+	CreatedDate    time.Time  `json:"created_date"`    //: "2013-04-09T18:41:23Z",
+	DeletedDate    *time.Time `json:"deleted_date"`    //: null,
+	Patient        int64      `json:"patient"`         //: 234160129,
+	Type           string     `json:"type"`            //: "PatientProblem",
+	IsConfidential bool       `json:"is_confidential"` //: false,
+	ItemType       string     `json:"itemType"`        //: "PatientProblem"
+}
+
+type VisitNoteNoteDocument struct {
+	ID       int64              `json:"id"`       //: 99483787,
+	Document *VisitNoteDocument `json:"document"` //: {}
+	Summary  any                `json:"summary"`  //: null
+}
+
+type VisitNoteDocument struct {
+	AuthoringPractice int64      `json:"authoring_practice"` // 65540,
+	ChartDate         time.Time  `json:"chart_date"`         // "2010-06-10T17:57:35Z",
+	CreatedDate       time.Time  `json:"created_date"`       // "2010-06-10T17:57:35Z",
+	DeletedDate       *time.Time `json:"deleted_date"`       // null,
+	DocumentDate      time.Time  `json:"document_date"`      // "2010-06-10T17:57:35Z",
+	DocumentType      int64      `json:"document_type"`      // 33,
+	ID                int64      `json:"id"`                 // 2687009,
+	LastModified      *time.Time `json:"last_modified"`      // null,
+	Patient           int64      `json:"patient"`            // 1638401,
+	SignDate          time.Time  `json:"sign_date"`          // "2010-06-10T17:57:35Z",
+	SignedBy          int64      `json:"signed_by"`          // 4
+}
+
+type VisitNoteChecklists struct {
+	PE  []*VisitNoteChecklistItem `json:"PE"`  //: [{}]   // Physical Exam
+	ROS []*VisitNoteChecklistItem `json:"ROS"` //: [{}]   // Review of Systems
+}
+
+type VisitNoteChecklistItem struct {
+	Name     string `json:"name"`     //: "General",
+	Value    string `json:"value"`    //: "well nourished",
+	Sequence int64  `json:"sequence"` // 0
+}
+
+type VisitNoteEdit struct {
+	VisitNote          int64     `json:"visit_note"`           //: 140755736526872,
+	CreateUser         int64     `json:"create_user"`          //: 1273,
+	CreatedDate        time.Time `json:"created_date"`         //: "2021-07-21T08:14:40Z",
+	PreviousNoteType   any       `json:"previous_note_type"`   //: null,
+	PreviousNoteTime   any       `json:"previous_note_time"`   //: null,
+	NewNoteType        any       `json:"new_note_type"`        //: null,
+	NewNoteTime        any       `json:"new_note_time"`        //: null,
+	PreviousPrevWeight any       `json:"previous_prev_weight"` //: null,
+	NewPrevWeight      any       `json:"new_prev_weight"`      //: null,
+	PreviousPrevBMI    any       `json:"previous_prev_bmi"`    //: null,
+	NewPrevBMI         any       `json:"new_prev_bmi"`         //: null,
+	PreviousPrevTime   any       `json:"previous_prev_time"`   //: null,
+	NewPrevTime        any       `json:"new_prev_time"`        //: null,
+	PreviousBMI        any       `json:"previous_bmi"`         //: null,
+	NewBMI             any       `json:"new_bmi"`              //: null,
+}
+
+type VisitNoteSignature struct {
+	User       int64     `json:"user"`        //: 12,
+	UserName   string    `json:"user_name"`   //: "Douglas Ross, MD",
+	SignedDate time.Time `json:"signed_date"` //: "2022-10-31T12:30:00Z",
+	Role       string    `json:"role"`        //: "cosigner",
+	Comments   any       `json:"comments"`    //: null
+}
+
+func (v *VisitNoteService) Create(ctx context.Context, create *VisitNoteCreate) (*VisitNote, *http.Response, error) {
+	ctx, span := v.client.tracer.Start(ctx, "create visit note", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	vn := &VisitNote{}
+
+	res, err := v.client.request(ctx, http.MethodPost, "/visit_notes", nil, create, &vn)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return vn, res, nil
+}

--- a/visit_note.go
+++ b/visit_note.go
@@ -66,9 +66,9 @@ type VisitNoteBullet struct {
 	Sequence       int64                  `json:"sequence"`         //: 0,
 	Author         int64                  `json:"author"`           //: 10,
 	UpdatedDate    time.Time              `json:"updated_date"`     //: "2022-05-15T13:50:09"
-	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
-	ReplacedBy     any                    `json:"replaced_by"`      //: null,
-	Edit           any                    `json:"edit"`             //: null,
+	ReplacedByEdit *string                `json:"replaced_by_edit"` //: null,
+	ReplacedBy     *string                `json:"replaced_by"`      //: null,
+	Edit           *string                `json:"edit"`             //: null,
 	DeletedDate    *time.Time             `json:"deleted_date"`     //: null,
 	NoteDocument   *VisitNoteNoteDocument `json:"note_document"`    //: null,
 	NoteItem       *VisitNoteNoteItem     `json:"note_item"`        //: null,
@@ -83,9 +83,9 @@ type VisitNoteChild struct {
 	Sequence       int64                  `json:"sequence"`         //: 0,
 	Author         int64                  `json:"author"`           //: 10,
 	UpdatedDate    time.Time              `json:"updated_date"`     //: "2022-05-15T13:50:09"
-	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
-	ReplacedBy     any                    `json:"replaced_by"`      //: null,
-	Edit           any                    `json:"edit"`             //: null,
+	ReplacedByEdit *string                `json:"replaced_by_edit"` //: null,
+	ReplacedBy     *string                `json:"replaced_by"`      //: null,
+	Edit           *string                `json:"edit"`             //: null,
 	DeletedDate    *time.Time             `json:"deleted_date"`     //: null,
 	NoteItem       *VisitNoteNoteItem     `json:"note_item"`        //: null,
 	NoteDocument   *VisitNoteNoteDocument `json:"note_document"`    //: null,
@@ -110,7 +110,7 @@ type VisitNoteItem struct {
 type VisitNoteNoteDocument struct {
 	ID       int64              `json:"id"`       //: 99483787,
 	Document *VisitNoteDocument `json:"document"` //: {}
-	Summary  any                `json:"summary"`  //: null
+	Summary  *string            `json:"summary"`  //: null
 }
 
 type VisitNoteDocument struct {
@@ -161,7 +161,7 @@ type VisitNoteSignature struct {
 	UserName   string    `json:"user_name"`   //: "Douglas Ross, MD",
 	SignedDate time.Time `json:"signed_date"` //: "2022-10-31T12:30:00Z",
 	Role       string    `json:"role"`        //: "cosigner",
-	Comments   any       `json:"comments"`    //: null
+	Comments   *string   `json:"comments"`    //: null
 }
 
 func (v *VisitNoteService) Create(ctx context.Context, create *VisitNoteCreate) (*VisitNote, *http.Response, error) {

--- a/visit_note_test.go
+++ b/visit_note_test.go
@@ -62,7 +62,7 @@ func TestVisitNoteService_Create(t *testing.T) {
 						UserName:   "John Doe",
 						SignedDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
 						Role:       "Physician",
-						Comments:   "Signed",
+						Comments:   new(string),
 					},
 				},
 			},

--- a/visit_note_test.go
+++ b/visit_note_test.go
@@ -1,0 +1,84 @@
+package elation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVisitNoteService_Create(t *testing.T) {
+	testCases := map[string]struct {
+		create *VisitNoteCreate
+	}{
+		"minimally-specified request": {
+			create: &VisitNoteCreate{
+				Bullets:      []*VisitNoteBullet{},
+				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				Patient:      12345,
+				Template:     "SOAP",
+				Physician:    12345,
+			},
+		},
+		"fully-specified request": {
+			create: &VisitNoteCreate{
+				Bullets:      []*VisitNoteBullet{},
+				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				Patient:      12345,
+				Template:     "SOAP",
+				Physician:    12345,
+				Type:         "Office Visit Note",
+				Confidential: true,
+				SignedBy:     12345,
+				SignedDate:   time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				Signatures:   []*VisitNoteSignature{},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tokenRequest(w, r) {
+					return
+				}
+
+				assert.Equal(http.MethodPost, r.Method)
+				assert.Equal("/visit_notes", r.URL.Path)
+
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(err)
+
+				create := &VisitNoteCreate{}
+				err = json.Unmarshal(body, create)
+				assert.NoError(err)
+
+				assert.Equal(testCase.create, create)
+
+				b, err := json.Marshal(&VisitNote{})
+				assert.NoError(err)
+
+				w.Header().Set("Content-Type", "application/json")
+				//nolint
+				w.Write(b)
+			}))
+			defer srv.Close()
+
+			client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			svc := VisitNoteService{client}
+
+			created, res, err := svc.Create(context.Background(), testCase.create)
+			assert.NotNil(created)
+			assert.NotNil(res)
+			assert.NoError(err)
+		})
+	}
+}

--- a/visit_note_test.go
+++ b/visit_note_test.go
@@ -18,7 +18,16 @@ func TestVisitNoteService_Create(t *testing.T) {
 	}{
 		"required fields only request": {
 			create: &VisitNoteCreate{
-				Bullets:      []*VisitNoteBullet{},
+				Bullets: []*VisitNoteBullet{
+					{
+						Category:    "Subjective",
+						Text:        "Patient",
+						Version:     1,
+						Sequence:    1,
+						Author:      12345,
+						UpdatedDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+					},
+				},
 				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
 				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
 				Patient:      12345,
@@ -28,7 +37,16 @@ func TestVisitNoteService_Create(t *testing.T) {
 		},
 		"all specified fields request": {
 			create: &VisitNoteCreate{
-				Bullets:      []*VisitNoteBullet{},
+				Bullets: []*VisitNoteBullet{
+					{
+						Category:    "Subjective",
+						Text:        "Patient",
+						Version:     1,
+						Sequence:    1,
+						Author:      12345,
+						UpdatedDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+					},
+				},
 				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
 				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
 				Patient:      12345,
@@ -38,7 +56,15 @@ func TestVisitNoteService_Create(t *testing.T) {
 				Confidential: true,
 				SignedBy:     12345,
 				SignedDate:   time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				Signatures:   []*VisitNoteSignature{},
+				Signatures: []*VisitNoteSignature{
+					{
+						User:       12345,
+						UserName:   "John Doe",
+						SignedDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+						Role:       "Physician",
+						Comments:   "Signed",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds the Visit Note and Bill structs and the create (POST) request for each one of them.

It follows the API documentation:
 - https://docs.elationhealth.com/reference/create-bill
 - https://docs.elationhealth.com/reference/create-visit-note

https://authorhealth.atlassian.net/browse/CM-392