### PR TITLE
Change Bill.serviceLocaltion type

### DIFF
--- a/bill.go
+++ b/bill.go
@@ -50,20 +50,20 @@ type Bill struct {
 }
 
 type BillCreate struct {
-	ServiceLocation     *BillServiceLocation `json:"service_location"`     //: {}           // required
-	VisitNoteID         int64                `json:"visit_note_id"`        //: 64409108504, // required
-	Patient             int64                `json:"patient"`              //: 64901939201, // required
-	Practice            int64                `json:"practice"`             //: 65540, 		  // required
-	Physician           int64                `json:"physician"`            //: 64811630594, // required
-	CPTs                []*BillCPT           `json:"cpts"`                 //: [{}],
-	BillingProvider     int64                `json:"billing_provider"`     //: 42120898,
-	RenderingProvider   int64                `json:"rendering_provider"`   //: 68382673,
-	SupervisingProvider int64                `json:"supervising_provider"` //: 52893234,
-	ReferringProvider   *BillProvider        `json:"referring_provider"`   //: {},
-	OrderingProvider    *BillProvider        `json:"ordering_provider"`    //: {},
-	PriorAuthorization  string               `json:"prior_authorization"`  //: "1234-ABC",
-	PaymentAmount       float64              `json:"payment_amount"`       //: 10.00,
-	Notes               string               `json:"notes"`                //: "patient has not paid yet",
+	ServiceLocation     int64         `json:"service_location"`     //: 10           // required
+	VisitNoteID         int64         `json:"visit_note_id"`        //: 64409108504, // required
+	Patient             int64         `json:"patient"`              //: 64901939201, // required
+	Practice            int64         `json:"practice"`             //: 65540, 		   // required
+	Physician           int64         `json:"physician"`            //: 64811630594, // required
+	CPTs                []*BillCPT    `json:"cpts"`                 //: [{}],
+	BillingProvider     int64         `json:"billing_provider"`     //: 42120898,
+	RenderingProvider   int64         `json:"rendering_provider"`   //: 68382673,
+	SupervisingProvider int64         `json:"supervising_provider"` //: 52893234,
+	ReferringProvider   *BillProvider `json:"referring_provider"`   //: {},
+	OrderingProvider    *BillProvider `json:"ordering_provider"`    //: {},
+	PriorAuthorization  string        `json:"prior_authorization"`  //: "1234-ABC",
+	PaymentAmount       float64       `json:"payment_amount"`       //: 10.00,
+	Notes               string        `json:"notes"`                //: "patient has not paid yet",
 }
 
 type BillCPT struct {

--- a/bill_test.go
+++ b/bill_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,44 +17,20 @@ func TestBillService_Create(t *testing.T) {
 	}{
 		"required fields only request": {
 			create: &BillCreate{
-				ServiceLocation: &BillServiceLocation{
-					ID:                 1,
-					Name:               "service location",
-					IsPrimary:          true,
-					PlaceOfService:     "office",
-					PlaceOfServiceCode: "11",
-					AddressLine1:       "123 Main St",
-					City:               "Schenectady",
-					State:              "NY",
-					Zip:                "12345",
-					Phone:              "555-234-5678",
-					CreatedDate:        time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				},
-				VisitNoteID: 64409108504,
-				Patient:     64901939201,
-				Practice:    65540,
-				Physician:   64811630594,
+				ServiceLocation: 10,
+				VisitNoteID:     64409108504,
+				Patient:         64901939201,
+				Practice:        65540,
+				Physician:       64811630594,
 			},
 		},
 		"all specified fields request": {
 			create: &BillCreate{
-				ServiceLocation: &BillServiceLocation{
-					ID:                 1,
-					Name:               "service location",
-					IsPrimary:          true,
-					PlaceOfService:     "office",
-					PlaceOfServiceCode: "11",
-					AddressLine1:       "123 Main St",
-					City:               "Schenectady",
-					State:              "NY",
-					Zip:                "12345",
-					Phone:              "555-234-5678",
-					CreatedDate:        time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
-				},
-				VisitNoteID: 64409108504,
-				Patient:     64901939201,
-				Practice:    65540,
-				Physician:   64811630594,
+				ServiceLocation: 10,
+				VisitNoteID:     64409108504,
+				Patient:         64901939201,
+				Practice:        65540,
+				Physician:       64811630594,
 				CPTs: []*BillCPT{
 					{
 						CPT:       12,


### PR DESCRIPTION
This PR changes the Bill.serviceLocation type from object BillServiceLocation to int64.

When creating the request to create a new Bill it requires the service location id.