### PR TITLE
Allow array fields on Patient to be empty

### DIFF
--- a/patient.go
+++ b/patient.go
@@ -261,29 +261,29 @@ func (s *PatientService) Get(ctx context.Context, id int64) (*Patient, *http.Res
 }
 
 type PatientUpdate struct {
-	ActualName             *string                   `json:"actual_name,omitempty"`
-	Address                *PatientAddress           `json:"address,omitempty"`
-	Consents               []*PatientConsent         `json:"consents,omitempty"`
-	DOB                    *string                   `json:"dob,omitempty"`
-	Emails                 *[]*PatientEmail          `json:"emails,omitempty"`
-	Ethnicity              *string                   `json:"ethnicity,omitempty"`
-	FirstName              *string                   `json:"first_name,omitempty"`
-	GenderIdentity         *string                   `json:"gender_identity,omitempty"`
-	Insurances             []*PatientInsuranceUpdate `json:"insurances,omitempty"`
-	LastName               *string                   `json:"last_name,omitempty"`
-	LegalGenderMarker      *string                   `json:"legal_gender_marker,omitempty"`
-	MiddleName             *string                   `json:"middle_name,omitempty"`
-	Notes                  *string                   `json:"notes,omitempty"`
-	PatientStatus          *PatientStatusUpdate      `json:"patient_status,omitempty"`
-	Phones                 *[]*PatientPhone          `json:"phones,omitempty"`
-	PreferredLanguage      *string                   `json:"preferred_language,omitempty"`
-	PrimaryCareProviderNPI *string                   `json:"primary_care_provider_npi,omitempty"`
-	PrimaryPhysician       *int64                    `json:"primary_physician,omitempty"`
-	Pronouns               *string                   `json:"pronouns,omitempty"`
-	Race                   *string                   `json:"race,omitempty"`
-	Sex                    *string                   `json:"sex,omitempty"`
-	SexualOrientation      *string                   `json:"sexual_orientation,omitempty"`
-	SSN                    *string                   `json:"ssn,omitempty"`
+	ActualName             *string                    `json:"actual_name,omitempty"`
+	Address                *PatientAddress            `json:"address,omitempty"`
+	Consents               *[]*PatientConsent         `json:"consents,omitempty"`
+	DOB                    *string                    `json:"dob,omitempty"`
+	Emails                 *[]*PatientEmail           `json:"emails,omitempty"`
+	Ethnicity              *string                    `json:"ethnicity,omitempty"`
+	FirstName              *string                    `json:"first_name,omitempty"`
+	GenderIdentity         *string                    `json:"gender_identity,omitempty"`
+	Insurances             *[]*PatientInsuranceUpdate `json:"insurances,omitempty"`
+	LastName               *string                    `json:"last_name,omitempty"`
+	LegalGenderMarker      *string                    `json:"legal_gender_marker,omitempty"`
+	MiddleName             *string                    `json:"middle_name,omitempty"`
+	Notes                  *string                    `json:"notes,omitempty"`
+	PatientStatus          *PatientStatusUpdate       `json:"patient_status,omitempty"`
+	Phones                 *[]*PatientPhone           `json:"phones,omitempty"`
+	PreferredLanguage      *string                    `json:"preferred_language,omitempty"`
+	PrimaryCareProviderNPI *string                    `json:"primary_care_provider_npi,omitempty"`
+	PrimaryPhysician       *int64                     `json:"primary_physician,omitempty"`
+	Pronouns               *string                    `json:"pronouns,omitempty"`
+	Race                   *string                    `json:"race,omitempty"`
+	Sex                    *string                    `json:"sex,omitempty"`
+	SexualOrientation      *string                    `json:"sexual_orientation,omitempty"`
+	SSN                    *string                    `json:"ssn,omitempty"`
 }
 
 type PatientInsuranceUpdate struct {

--- a/patient.go
+++ b/patient.go
@@ -265,7 +265,7 @@ type PatientUpdate struct {
 	Address                *PatientAddress           `json:"address,omitempty"`
 	Consents               []*PatientConsent         `json:"consents,omitempty"`
 	DOB                    *string                   `json:"dob,omitempty"`
-	Emails                 []*PatientEmail           `json:"emails,omitempty"`
+	Emails                 *[]*PatientEmail          `json:"emails,omitempty"`
 	Ethnicity              *string                   `json:"ethnicity,omitempty"`
 	FirstName              *string                   `json:"first_name,omitempty"`
 	GenderIdentity         *string                   `json:"gender_identity,omitempty"`
@@ -275,7 +275,7 @@ type PatientUpdate struct {
 	MiddleName             *string                   `json:"middle_name,omitempty"`
 	Notes                  *string                   `json:"notes,omitempty"`
 	PatientStatus          *PatientStatusUpdate      `json:"patient_status,omitempty"`
-	Phones                 []*PatientPhone           `json:"phones,omitempty"`
+	Phones                 *[]*PatientPhone          `json:"phones,omitempty"`
 	PreferredLanguage      *string                   `json:"preferred_language,omitempty"`
 	PrimaryCareProviderNPI *string                   `json:"primary_care_provider_npi,omitempty"`
 	PrimaryPhysician       *int64                    `json:"primary_physician,omitempty"`

--- a/patient_test.go
+++ b/patient_test.go
@@ -254,11 +254,11 @@ func TestPatientService_Update(t *testing.T) {
 			},
 		},
 		DOB: Ptr("dob"),
-		Emails: []*PatientEmail{
+		Emails: Ptr([]*PatientEmail{
 			{
 				Email: "email",
 			},
-		},
+		}),
 		Ethnicity:      Ptr("ethnicity"),
 		FirstName:      Ptr("first name"),
 		GenderIdentity: Ptr("gender identity name"),
@@ -305,12 +305,12 @@ func TestPatientService_Update(t *testing.T) {
 			InactiveReason: Ptr("other"),
 			Status:         Ptr("inactive"),
 		},
-		Phones: []*PatientPhone{
+		Phones: Ptr([]*PatientPhone{
 			{
 				Phone:     "phone",
 				PhoneType: "phone type",
 			},
-		},
+		}),
 		PreferredLanguage:      Ptr("preferred language"),
 		PrimaryCareProviderNPI: Ptr("primary care provider NPI"),
 		PrimaryPhysician:       Ptr[int64](1),

--- a/patient_test.go
+++ b/patient_test.go
@@ -247,12 +247,12 @@ func TestPatientService_Update(t *testing.T) {
 			State:        "state",
 			Zip:          "zip",
 		},
-		Consents: []*PatientConsent{
+		Consents: Ptr([]*PatientConsent{
 			{
 				ConsentType: "consent type",
 				Expiration:  "expiration",
 			},
-		},
+		}),
 		DOB: Ptr("dob"),
 		Emails: Ptr([]*PatientEmail{
 			{
@@ -262,7 +262,7 @@ func TestPatientService_Update(t *testing.T) {
 		Ethnicity:      Ptr("ethnicity"),
 		FirstName:      Ptr("first name"),
 		GenderIdentity: Ptr("gender identity name"),
-		Insurances: []*PatientInsuranceUpdate{
+		Insurances: Ptr([]*PatientInsuranceUpdate{
 			{
 				InsuranceCompany:       Ptr[int64](1),
 				InsurancePlan:          Ptr[int64](2),
@@ -296,7 +296,7 @@ func TestPatientService_Update(t *testing.T) {
 				EndDate:                &civil.Date{Year: 3000, Month: 1, Day: 1},
 			},
 			{},
-		},
+		}),
 		LastName:          Ptr("last name"),
 		LegalGenderMarker: Ptr("legal gender marker"),
 		MiddleName:        Ptr("middle name"),


### PR DESCRIPTION
Due to the combination of how `PatientUpdate` is structured and how JSON serialization works in Go, it has not been possible to completely remove emails and phones from a Patient record.

This PR updates `PatientUpdate` so that if `Emails` or `Phones` is non-nil, the field will be included in the JSON serialization output, even if the slice the field points to is empty. This allows consumers of the client to pass an empty array for these fields to Elation to allow them to be completely cleared.

If `Emails` or `Phones` is nil, then it will not be included in the JSON serialization output. This allows consumers of the client to change other fields on the Patient record without affecting emails or phones.

For consistency, the `Consents` and `Insurances` fields have been similarly modified to allow the fields in the Patient record to be cleared.