### PR TITLE
Treat pointers to nil slices as empty for Patient updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0

--- a/json.go
+++ b/json.go
@@ -1,0 +1,33 @@
+package elation
+
+import "encoding/json"
+
+// NonNullJSONArray ensures that nil slices are marshalled to "[]" instead of "null". It also ensures that empty JSON arrays
+// are marshalled to nil slices.
+type NonNullJSONArray[T any] []T
+
+func (nnja NonNullJSONArray[T]) MarshalJSON() ([]byte, error) {
+	if nnja == nil {
+		nnja = make([]T, 0)
+	}
+
+	return json.Marshal([]T(nnja))
+}
+
+func (nnja *NonNullJSONArray[T]) UnmarshalJSON(data []byte) error {
+	type alias NonNullJSONArray[T]
+	var a alias
+
+	err := json.Unmarshal(data, &a)
+	if err != nil {
+		return err
+	}
+
+	if len(a) == 0 {
+		return nil
+	}
+
+	*nnja = NonNullJSONArray[T](a)
+
+	return nil
+}

--- a/patient.go
+++ b/patient.go
@@ -261,29 +261,29 @@ func (s *PatientService) Get(ctx context.Context, id int64) (*Patient, *http.Res
 }
 
 type PatientUpdate struct {
-	ActualName             *string                    `json:"actual_name,omitempty"`
-	Address                *PatientAddress            `json:"address,omitempty"`
-	Consents               *[]*PatientConsent         `json:"consents,omitempty"`
-	DOB                    *string                    `json:"dob,omitempty"`
-	Emails                 *[]*PatientEmail           `json:"emails,omitempty"`
-	Ethnicity              *string                    `json:"ethnicity,omitempty"`
-	FirstName              *string                    `json:"first_name,omitempty"`
-	GenderIdentity         *string                    `json:"gender_identity,omitempty"`
-	Insurances             *[]*PatientInsuranceUpdate `json:"insurances,omitempty"`
-	LastName               *string                    `json:"last_name,omitempty"`
-	LegalGenderMarker      *string                    `json:"legal_gender_marker,omitempty"`
-	MiddleName             *string                    `json:"middle_name,omitempty"`
-	Notes                  *string                    `json:"notes,omitempty"`
-	PatientStatus          *PatientStatusUpdate       `json:"patient_status,omitempty"`
-	Phones                 *[]*PatientPhone           `json:"phones,omitempty"`
-	PreferredLanguage      *string                    `json:"preferred_language,omitempty"`
-	PrimaryCareProviderNPI *string                    `json:"primary_care_provider_npi,omitempty"`
-	PrimaryPhysician       *int64                     `json:"primary_physician,omitempty"`
-	Pronouns               *string                    `json:"pronouns,omitempty"`
-	Race                   *string                    `json:"race,omitempty"`
-	Sex                    *string                    `json:"sex,omitempty"`
-	SexualOrientation      *string                    `json:"sexual_orientation,omitempty"`
-	SSN                    *string                    `json:"ssn,omitempty"`
+	ActualName             *string                                    `json:"actual_name,omitempty"`
+	Address                *PatientAddress                            `json:"address,omitempty"`
+	Consents               *NonNullJSONArray[*PatientConsent]         `json:"consents,omitempty"`
+	DOB                    *string                                    `json:"dob,omitempty"`
+	Emails                 *NonNullJSONArray[*PatientEmail]           `json:"emails,omitempty"`
+	Ethnicity              *string                                    `json:"ethnicity,omitempty"`
+	FirstName              *string                                    `json:"first_name,omitempty"`
+	GenderIdentity         *string                                    `json:"gender_identity,omitempty"`
+	Insurances             *NonNullJSONArray[*PatientInsuranceUpdate] `json:"insurances,omitempty"`
+	LastName               *string                                    `json:"last_name,omitempty"`
+	LegalGenderMarker      *string                                    `json:"legal_gender_marker,omitempty"`
+	MiddleName             *string                                    `json:"middle_name,omitempty"`
+	Notes                  *string                                    `json:"notes,omitempty"`
+	PatientStatus          *PatientStatusUpdate                       `json:"patient_status,omitempty"`
+	Phones                 *NonNullJSONArray[*PatientPhone]           `json:"phones,omitempty"`
+	PreferredLanguage      *string                                    `json:"preferred_language,omitempty"`
+	PrimaryCareProviderNPI *string                                    `json:"primary_care_provider_npi,omitempty"`
+	PrimaryPhysician       *int64                                     `json:"primary_physician,omitempty"`
+	Pronouns               *string                                    `json:"pronouns,omitempty"`
+	Race                   *string                                    `json:"race,omitempty"`
+	Sex                    *string                                    `json:"sex,omitempty"`
+	SexualOrientation      *string                                    `json:"sexual_orientation,omitempty"`
+	SSN                    *string                                    `json:"ssn,omitempty"`
 }
 
 type PatientInsuranceUpdate struct {


### PR DESCRIPTION
The Elation API doesn't accept `null` for some Patient fields when attempting to clear them out. To avoid calling the Patient update API with `null` field values, this PR ensures that pointers to nil slices are marshalled to `[]` instead of `null`.