### PR TITLE
Update group pattern and pin actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
           - "golang.org/x/*"
       otel:
         patterns:
+          - "go.opentelemetry.io/otel"
           - "go.opentelemetry.io/otel/*"
           - "go.opentelemetry.io/contrib/*"
     labels:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,16 +14,16 @@ permissions:
   checks: write
 
 env:
-  GOLANGCI_LINT_VERSION: v1.60.1
+  GOLANGCI_LINT_VERSION: v1.64.8
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: './go.mod'
           cache: true
@@ -32,7 +32,7 @@ jobs:
             cli/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,16 +6,16 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    permissions:
-      contents: "read"
-
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: './go.mod'
           cache: true


### PR DESCRIPTION
Ensure that the root OTel package is included in the group. This should result in fewer Dependabot PRs.

Also pin GitHub actions to their SHAs to avoid vulnerabilities from tag hijacking.