### PR TITLE
Add Mode to appointment create opts

### DIFF
--- a/appointment.go
+++ b/appointment.go
@@ -42,6 +42,7 @@ type AppointmentService struct {
 type AppointmentCreate struct {
 	Description     *string   `json:"description"`
 	Duration        int64     `json:"duration"`
+	Mode            string    `json:"mode"`
 	Patient         int64     `json:"patient"`
 	Physician       int64     `json:"physician"`
 	Practice        int64     `json:"practice"`

--- a/appointment_test.go
+++ b/appointment_test.go
@@ -21,6 +21,7 @@ func TestAppointmentService_Create(t *testing.T) {
 	expected := &AppointmentCreate{
 		Description:     Ptr("description"),
 		Duration:        60,
+		Mode:            "IN_PERSON",
 		Patient:         1,
 		Physician:       2,
 		Practice:        3,


### PR DESCRIPTION
While not documented in the [Create Appointment API docs](https://docs.elationhealth.com/reference/create-appointment), Elation has confirmed that `Mode` can be passed in this API, and that this functionality can be relied upon for integrations.