### PR TITLE
Add support for fetching a Pharmacy, update type on patient preferred pharmacies

### DIFF
--- a/cli/cmd/pharmacy.go
+++ b/cli/cmd/pharmacy.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/authorhealth/go-elation"
+	"github.com/spf13/cobra"
+)
+
+var getPharmacyCmd = &cobra.Command{
+	Use:  "get-pharmacy [pharmacy NCPDPID]",
+	Args: cobra.ExactArgs(1),
+	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
+		ncpdpid := args[0]
+		response, _, err := client.Pharmacies().Get(ctx, ncpdpid)
+		if err != nil {
+			return err
+		}
+
+		responseJson, err := json.Marshal(response)
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprintln(os.Stdout, string(responseJson))
+
+		return err
+	}),
+}
+
+func init() {
+	rootCmd.AddCommand(getPharmacyCmd)
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	cloud.google.com/go v0.120.0 // indirect
+	cloud.google.com/go v0.120.1 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,5 +1,5 @@
-cloud.google.com/go v0.120.0 h1:wc6bgG9DHyKqF5/vQvX1CiZrtHnxJjBlKUyF9nP6meA=
-cloud.google.com/go v0.120.0/go.mod h1:/beW32s8/pGRuj4IILWQNd4uuebeT4dkOhKmkfit64Q=
+cloud.google.com/go v0.120.1 h1:Z+5V7yd383+9617XDCyszmK5E4wJRJL+tquMfDj9hLM=
+cloud.google.com/go v0.120.1/go.mod h1:56Vs7sf/i2jYM6ZL9NYlC82r04PThNcPS5YgFmb0rp8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/client.go
+++ b/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	MessageThreads() MessageThreadServicer
 	NonVisitNotes() NonVisitNoteServicer
 	Patients() PatientServicer
+	Pharmacies() PharmacyServicer
 	Physicians() PhysicianServicer
 	Practices() PracticeServicer
 	PrescriptionFills() PrescriptionFillServicer
@@ -68,6 +69,7 @@ type HTTPClient struct {
 	MessageThreadSvc           *MessageThreadService
 	NonVisitNoteSvc            *NonVisitNoteService
 	PatientSvc                 *PatientService
+	PharmacySvc                *PharmacyService
 	PhysicianSvc               *PhysicianService
 	PracticeSvc                *PracticeService
 	PrescriptionFillSvc        *PrescriptionFillService
@@ -114,6 +116,7 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 	client.MessageThreadSvc = &MessageThreadService{client}
 	client.NonVisitNoteSvc = &NonVisitNoteService{client}
 	client.PatientSvc = &PatientService{client}
+	client.PharmacySvc = &PharmacyService{client}
 	client.PhysicianSvc = &PhysicianService{client}
 	client.PracticeSvc = &PracticeService{client}
 	client.PrescriptionFillSvc = &PrescriptionFillService{client}
@@ -181,6 +184,10 @@ func (c *HTTPClient) NonVisitNotes() NonVisitNoteServicer {
 
 func (c *HTTPClient) Patients() PatientServicer {
 	return c.PatientSvc
+}
+
+func (c *HTTPClient) Pharmacies() PharmacyServicer {
+	return c.PharmacySvc
 }
 
 func (c *HTTPClient) Physicians() PhysicianServicer {

--- a/patient.go
+++ b/patient.go
@@ -184,8 +184,8 @@ type PatientStatus struct {
 }
 
 type PatientPreference struct {
-	PreferredPharmacy1 any `json:"preferred_pharmacy_1"`
-	PreferredPharmacy2 any `json:"preferred_pharmacy_2"`
+	PreferredPharmacy1 *string `json:"preferred_pharmacy_1"`
+	PreferredPharmacy2 *string `json:"preferred_pharmacy_2"`
 }
 
 type PatientContact struct {

--- a/pharmacy.go
+++ b/pharmacy.go
@@ -1,0 +1,55 @@
+package elation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type PharmacyServicer interface {
+	Get(ctx context.Context, ncpdpid string) (*Pharmacy, *http.Response, error)
+}
+
+var _ PharmacyServicer = (*PharmacyService)(nil)
+
+type PharmacyService struct {
+	client *HTTPClient
+}
+
+type Pharmacy struct {
+	ID              int64     `json:"id"`
+	NCPDPID         string    `json:"ncpdpid"`
+	StoreName       string    `json:"store_name"`
+	AddressLine1    string    `json:"address_line1"`
+	AddressLine2    string    `json:"address_line2"`
+	City            string    `json:"city"`
+	State           string    `json:"state"`
+	Zip             string    `json:"zip"`
+	PhonePrimary    string    `json:"phone_primary"`
+	Fax             string    `json:"fax"`
+	NPI             string    `json:"npi"`
+	ActiveStartTime time.Time `json:"active_start_time"`
+	ActiveEndTime   time.Time `json:"active_end_time"`
+	SpecialityTypes string    `json:"specialty_types"`
+}
+
+func (s *PharmacyService) Get(ctx context.Context, ncpdpid string) (*Pharmacy, *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "get pharmacy", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("elation.pharmacy_ncpdpid", ncpdpid)))
+	defer span.End()
+
+	out := &Pharmacy{}
+
+	res, err := s.client.request(ctx, http.MethodGet, fmt.Sprintf("/pharmacies/%s", ncpdpid), nil, nil, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}

--- a/pharmacy_test.go
+++ b/pharmacy_test.go
@@ -1,0 +1,45 @@
+package elation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPharmacyService_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	ncpdpid := "1234789"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/pharmacies/"+ncpdpid, r.URL.Path)
+
+		b, err := json.Marshal(&Pharmacy{
+			ID:      123,
+			NCPDPID: ncpdpid,
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := PharmacyService{client}
+
+	found, res, err := svc.Get(context.Background(), ncpdpid)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}


### PR DESCRIPTION
This PR adds support for fetching a Pharmacy by its NCPDPID, primarily to support fetching details on preferred patient pharmacies. The types on the `Patient.Preference` are updated accordingly from `any`.