### PR TITLE
PH-401 - Add Allergy Documentation servicer

### DIFF
--- a/allergy_documentation.go
+++ b/allergy_documentation.go
@@ -1,0 +1,69 @@
+package elation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type AllergyDocumentationServicer interface {
+	Find(ctx context.Context, opts *FindAllergiesDocumentationOptions) (*Response[[]*AllergyDocumentation], *http.Response, error)
+	Get(ctx context.Context, id int64) (*AllergyDocumentation, *http.Response, error)
+}
+
+var _ AllergyDocumentationServicer = (*AllergyDocumentationService)(nil)
+
+type AllergyDocumentationService struct {
+	client *HTTPClient
+}
+
+type AllergyDocumentation struct {
+	ID          int64      `json:"id"`
+	Patient     int64      `json:"patient"`
+	CreatedDate time.Time  `json:"created_date"`
+	DeletedDate *time.Time `json:"deleted_date"`
+}
+
+type FindAllergiesDocumentationOptions struct {
+	*Pagination
+
+	Patient []int64 `url:"patient,omitempty"`
+}
+
+func (s *AllergyDocumentationService) Find(ctx context.Context, opts *FindAllergiesDocumentationOptions) (*Response[[]*AllergyDocumentation], *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "find allergies documentation", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	out := &Response[[]*AllergyDocumentation]{}
+
+	res, err := s.client.request(ctx, http.MethodGet, "/allergies_documentation", opts, nil, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}
+
+func (s *AllergyDocumentationService) Get(ctx context.Context, id int64) (*AllergyDocumentation, *http.Response, error) {
+	ctx, span := s.client.tracer.Start(ctx, "get allergy documentation", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.Int64("elation.allergy_documentation_id", id)))
+	defer span.End()
+
+	out := &AllergyDocumentation{}
+
+	res, err := s.client.request(ctx, http.MethodGet, "/allergies_documentation/"+strconv.FormatInt(id, 10), nil, nil, &out)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "error making request")
+		return nil, res, fmt.Errorf("making request: %w", err)
+	}
+
+	return out, res, nil
+}

--- a/allergy_documentation.go
+++ b/allergy_documentation.go
@@ -37,12 +37,12 @@ type FindAllergiesDocumentationOptions struct {
 }
 
 func (s *AllergyDocumentationService) Find(ctx context.Context, opts *FindAllergiesDocumentationOptions) (*Response[[]*AllergyDocumentation], *http.Response, error) {
-	ctx, span := s.client.tracer.Start(ctx, "find allergies documentation", trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := s.client.tracer.Start(ctx, "find allergy documentation", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	out := &Response[[]*AllergyDocumentation]{}
 
-	res, err := s.client.request(ctx, http.MethodGet, "/allergies_documentation", opts, nil, &out)
+	res, err := s.client.request(ctx, http.MethodGet, "/allergy_documentation", opts, nil, &out)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "error making request")
@@ -58,7 +58,7 @@ func (s *AllergyDocumentationService) Get(ctx context.Context, id int64) (*Aller
 
 	out := &AllergyDocumentation{}
 
-	res, err := s.client.request(ctx, http.MethodGet, "/allergies_documentation/"+strconv.FormatInt(id, 10), nil, nil, &out)
+	res, err := s.client.request(ctx, http.MethodGet, "/allergy_documentation/"+strconv.FormatInt(id, 10), nil, nil, &out)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "error making request")

--- a/allergy_documentation_test.go
+++ b/allergy_documentation_test.go
@@ -1,0 +1,101 @@
+package elation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllergyDocumentationService_Find(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := &FindAllergiesDocumentationOptions{
+		Pagination: &Pagination{
+			Limit:  1,
+			Offset: 2,
+		},
+
+		Patient: []int64{1},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/allergies_documentation", r.URL.Path)
+
+		patient := r.URL.Query()["patient"]
+
+		limit := r.URL.Query().Get("limit")
+		offset := r.URL.Query().Get("offset")
+
+		assert.Equal(opts.Patient, sliceStrToInt64(patient))
+		assert.Equal(opts.Limit, strToInt(limit))
+		assert.Equal(opts.Offset, strToInt(offset))
+
+		b, err := json.Marshal(Response[[]*AllergyDocumentation]{
+			Results: []*AllergyDocumentation{
+				{
+					ID: 1,
+				},
+				{
+					ID: 2,
+				},
+			},
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := AllergyDocumentationService{client}
+
+	found, res, err := svc.Find(context.Background(), opts)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestAllergyDocumentationService_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 1
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/allergies_documentation/"+strconv.FormatInt(id, 10), r.URL.Path)
+
+		b, err := json.Marshal(&AllergyDocumentation{
+			ID: id,
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := AllergyDocumentationService{client}
+
+	found, res, err := svc.Get(context.Background(), id)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}

--- a/allergy_documentation_test.go
+++ b/allergy_documentation_test.go
@@ -29,7 +29,7 @@ func TestAllergyDocumentationService_Find(t *testing.T) {
 		}
 
 		assert.Equal(http.MethodGet, r.Method)
-		assert.Equal("/allergies_documentation", r.URL.Path)
+		assert.Equal("/allergy_documentation", r.URL.Path)
 
 		patient := r.URL.Query()["patient"]
 
@@ -78,7 +78,7 @@ func TestAllergyDocumentationService_Get(t *testing.T) {
 		}
 
 		assert.Equal(http.MethodGet, r.Method)
-		assert.Equal("/allergies_documentation/"+strconv.FormatInt(id, 10), r.URL.Path)
+		assert.Equal("/allergy_documentation/"+strconv.FormatInt(id, 10), r.URL.Path)
 
 		b, err := json.Marshal(&AllergyDocumentation{
 			ID: id,

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ const (
 
 type Client interface {
 	Allergies() AllergyServicer
+	AllergyDocumentation() AllergyDocumentationServicer
 	Appointments() AppointmentServicer
 	Bill() BillServicer
 	ClinicalDocuments() ClinicalDocumentServicer
@@ -57,6 +58,7 @@ type HTTPClient struct {
 	tracer     trace.Tracer
 
 	AllergySvc                 *AllergyService
+	AllergyDocumentationSvc    *AllergyDocumentationService
 	AppointmentSvc             *AppointmentService
 	BillSvc                    *BillService
 	ClinicalDocumentSvc        *ClinicalDocumentService
@@ -105,6 +107,7 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 	}
 
 	client.AllergySvc = &AllergyService{client}
+	client.AllergyDocumentationSvc = &AllergyDocumentationService{client}
 	client.AppointmentSvc = &AppointmentService{client}
 	client.BillSvc = &BillService{client}
 	client.ClinicalDocumentSvc = &ClinicalDocumentService{client}
@@ -135,6 +138,10 @@ func NewHTTPClient(httpClient *http.Client, tokenURL, clientID, clientSecret, ba
 
 func (c *HTTPClient) Allergies() AllergyServicer {
 	return c.AllergySvc
+}
+
+func (c *HTTPClient) AllergyDocumentation() AllergyDocumentationServicer {
+	return c.AllergyDocumentationSvc
 }
 
 func (c *HTTPClient) Appointments() AppointmentServicer {


### PR DESCRIPTION
This PR adds the Allergy Documentation servicer.

The Allergy Documentation will help us identify if the allergy is documented (known allergy), related docs below:

https://docs.elationhealth.com/reference/the-allergy-documentation-nkda-object