### PR TITLE
Add client support for getting a visit note by ID

### DIFF
--- a/visit_note.go
+++ b/visit_note.go
@@ -93,7 +93,7 @@ type VisitNoteChild struct {
 	DeletedDate    *time.Time             `json:"deleted_date"`     //: null,
 	NoteItem       *VisitNoteNoteItem     `json:"note_item"`        //: null,
 	NoteDocument   *VisitNoteNoteDocument `json:"note_document"`    //: null,
-	Handout        int64                  `json:"handout"`          //: 140758529736869
+	Handout        *int64                 `json:"handout"`          //: 140758529736869
 }
 
 type VisitNoteNoteItem struct {

--- a/visit_note_test.go
+++ b/visit_note_test.go
@@ -221,3 +221,36 @@ func TestVisitNoteService_Delete(t *testing.T) {
 	assert.NotNil(res)
 	assert.NoError(err)
 }
+
+func TestVisitNoteService_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 123456
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/visit_notes/"+strconv.FormatInt(id, 10), r.URL.Path)
+
+		b, err := json.Marshal(&VisitNote{
+			ID: id,
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := VisitNoteService{client}
+
+	found, res, err := svc.Get(context.Background(), id)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}


### PR DESCRIPTION
ref: https://docs.elationhealth.com/reference/get-visit-note

Also fixes an issue with `VisitNoteChild` that prevents adding child bullets without handouts.