### PR TITLE
Correct VisitNoteChild.UpdatedDate type

### DIFF
--- a/visit_note.go
+++ b/visit_note.go
@@ -86,7 +86,7 @@ type VisitNoteChild struct {
 	Version        int64                  `json:"version"`          //: 1,
 	Sequence       int64                  `json:"sequence"`         //: 0,
 	Author         int64                  `json:"author"`           //: 10,
-	UpdatedDate    time.Time              `json:"updated_date"`     //: "2022-05-15T13:50:09"
+	UpdatedDate    string                 `json:"updated_date"`     //: "2022-05-15T13:50:09" (Missing TZ offset, but can assume PT)
 	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
 	ReplacedBy     any                    `json:"replaced_by"`      //: null,
 	Edit           any                    `json:"edit"`             //: null,


### PR DESCRIPTION
`updated_date` on a note bullet is given in local time (specifically, PT) and as such is missing the timezone offset. This causes issues unmarshalling to a `time.Time`, since it's not considered a strict RFC3339 timestamp without timezone/location information.

(Case opened upstream w/ Elation, as it differs with all other datetime fields)