### PR TITLE
Make VisitNoteChild.UpdatedDate nilable

### DIFF
--- a/visit_note.go
+++ b/visit_note.go
@@ -86,7 +86,7 @@ type VisitNoteChild struct {
 	Version        int64                  `json:"version"`          //: 1,
 	Sequence       int64                  `json:"sequence"`         //: 0,
 	Author         int64                  `json:"author"`           //: 10,
-	UpdatedDate    string                 `json:"updated_date"`     //: "2022-05-15T13:50:09" (Missing TZ offset, but can assume PT)
+	UpdatedDate    *string                `json:"updated_date"`     //: "2022-05-15T13:50:09" (Missing TZ offset, but can assume PT)
 	ReplacedByEdit any                    `json:"replaced_by_edit"` //: null,
 	ReplacedBy     any                    `json:"replaced_by"`      //: null,
 	Edit           any                    `json:"edit"`             //: null,


### PR DESCRIPTION
We don't specify this at visit note creation and the Elation API will not allow an empty value here.

Previous use of `time.Time` meant we were at least providing a well-formed value (`0001-01-01T00:00:00Z`), even if it was likely getting ignored/immediately overwritten