### PR TITLE
Add support for non-visit note creation endpoint

### DIFF
--- a/non_visit_note_test.go
+++ b/non_visit_note_test.go
@@ -3,13 +3,93 @@ package elation
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNonVisitNoteService_Create(t *testing.T) {
+	testCases := map[string]struct {
+		create *NonVisitNoteCreate
+	}{
+		"required fields only request": {
+			create: &NonVisitNoteCreate{
+				Bullets: []*NonVisitNoteBullet{
+					{
+						Text:    "Patient",
+						Version: 1,
+						Author:  12345,
+					},
+				},
+				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				Patient:      12345,
+				Type:         "nonvisit",
+			},
+		},
+		"signed fields request": {
+			create: &NonVisitNoteCreate{
+				Bullets: []*NonVisitNoteBullet{
+					{
+						Text:    "Patient",
+						Version: 1,
+						Author:  12345,
+					},
+				},
+				ChartDate:    time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				DocumentDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
+				Patient:      12345,
+				Type:         "nonvisit",
+				SignedBy:     12345,
+				SignedDate:   Ptr(time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tokenRequest(w, r) {
+					return
+				}
+
+				assert.Equal(http.MethodPost, r.Method)
+				assert.Equal("/non_visit_notes", r.URL.Path)
+
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(err)
+
+				create := &NonVisitNoteCreate{}
+				err = json.Unmarshal(body, create)
+				assert.NoError(err)
+
+				assert.Equal(testCase.create, create)
+
+				b, err := json.Marshal(&NonVisitNote{})
+				assert.NoError(err)
+
+				w.Header().Set("Content-Type", "application/json")
+				//nolint
+				w.Write(b)
+			}))
+			defer srv.Close()
+
+			client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+			svc := NonVisitNoteService{client}
+
+			created, res, err := svc.Create(context.Background(), testCase.create)
+			assert.NotNil(created)
+			assert.NotNil(res)
+			assert.NoError(err)
+		})
+	}
+}
 
 func TestNonVisitNoteService_Find(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
Adds support for the `POST /api/2.0/non_visit_notes` endpoint

https://docs.elationhealth.com/reference/create-non-visit-note

The docs aren't entirely accurate here and are missing the `signed_by` and `signed_date` fields, which do work and are included here. The bullet definitions also seem to be copied from the Visit Note docs, but are reflected properly on our `NonVisitNoteBullet` type, as far as I can tell (e.g. no `category` or `sequence` fields)