### PR TITLE
Add temporary fix for timestamps without timezone

### DIFF
--- a/insurance_eligibility.go
+++ b/insurance_eligibility.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -47,7 +46,7 @@ func (s *InsuranceEligibilityService) Create(ctx context.Context, patientInsuran
 
 type InsuranceEligibility struct {
 	EligibilityDetails        *InsuranceEligibilityDetails `json:"eligibility_details"`
-	EligibilityCheckTimestamp time.Time                    `json:"eligibility_check_timestamp"`
+	EligibilityCheckTimestamp timeWithOptionalZone         `json:"eligibility_check_timestamp"`
 	EligibilityStatus         string                       `json:"eligibility_status"`
 	PatientID                 int64                        `json:"patient_id"`
 	PatientInsuranceID        int64                        `json:"patient_insurance_id"`
@@ -83,7 +82,7 @@ func (s *InsuranceEligibilityService) Get(ctx context.Context, patientInsuranceI
 }
 
 type InsuranceEligibilityFullReport struct {
-	EligibilityCheckTimestamp time.Time               `json:"eligibility_check_timestamp"`
+	EligibilityCheckTimestamp timeWithOptionalZone    `json:"eligibility_check_timestamp"`
 	PatientID                 int64                   `json:"patient_id"`
 	PatientInsuranceID        int64                   `json:"patient_insurance_id"`
 	PracticeID                int64                   `json:"practice_id"`

--- a/insurance_eligibility.go
+++ b/insurance_eligibility.go
@@ -46,7 +46,7 @@ func (s *InsuranceEligibilityService) Create(ctx context.Context, patientInsuran
 
 type InsuranceEligibility struct {
 	EligibilityDetails        *InsuranceEligibilityDetails `json:"eligibility_details"`
-	EligibilityCheckTimestamp timeWithOptionalZone         `json:"eligibility_check_timestamp"`
+	EligibilityCheckTimestamp TimeWithOptionalZone         `json:"eligibility_check_timestamp"`
 	EligibilityStatus         string                       `json:"eligibility_status"`
 	PatientID                 int64                        `json:"patient_id"`
 	PatientInsuranceID        int64                        `json:"patient_insurance_id"`
@@ -82,7 +82,7 @@ func (s *InsuranceEligibilityService) Get(ctx context.Context, patientInsuranceI
 }
 
 type InsuranceEligibilityFullReport struct {
-	EligibilityCheckTimestamp timeWithOptionalZone    `json:"eligibility_check_timestamp"`
+	EligibilityCheckTimestamp TimeWithOptionalZone    `json:"eligibility_check_timestamp"`
 	PatientID                 int64                   `json:"patient_id"`
 	PatientInsuranceID        int64                   `json:"patient_insurance_id"`
 	PracticeID                int64                   `json:"practice_id"`

--- a/tz.go
+++ b/tz.go
@@ -1,0 +1,52 @@
+package elation
+
+import (
+	"fmt"
+	"time"
+)
+
+var defaultTimezone *time.Location
+
+type timeWithOptionalZone struct {
+	time.Time
+}
+
+func init() {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		defaultTimezone = time.UTC
+	} else {
+		defaultTimezone = loc
+	}
+}
+
+func (t *timeWithOptionalZone) UnmarshalJSON(b []byte) (err error) {
+	s := string(b)
+
+	if s == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return fmt.Errorf("invalid time string format: %s", s)
+	}
+
+	s = s[1 : len(s)-1]
+
+	// If RFC3339 fails, try parsing ISO8601 without zone
+	var rfc3339Err error
+	t.Time, rfc3339Err = time.Parse(time.RFC3339, s)
+	if rfc3339Err == nil {
+		return nil
+	}
+
+	var noZoneErr error
+	parsedTime, errNoZone := time.ParseInLocation("2006-01-02T15:04:05", s, defaultTimezone)
+	if errNoZone == nil {
+		t.Time = parsedTime
+		return nil
+	}
+
+	return fmt.Errorf("parsing time: RFC3339 %w or ISO8061 with no zone %w", rfc3339Err, noZoneErr)
+}

--- a/tz_test.go
+++ b/tz_test.go
@@ -1,0 +1,58 @@
+package elation
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeWithOptionalZone_UnmarshalJSON(t *testing.T) {
+	laLoc, err := time.LoadLocation("America/Los_Angeles")
+	assert.NoError(t, err)
+
+	testCases := map[string]struct {
+		jsonValue     string
+		expectedError string
+		expectedValue TimeWithOptionalZone
+	}{
+		"empty JSON value": {
+			jsonValue:     "",
+			expectedError: "unexpected end of JSON input",
+		},
+		"null JSON value": {
+			jsonValue:     "null",
+			expectedValue: TimeWithOptionalZone{},
+		},
+		"numeric JSON value": {
+			jsonValue:     "12345",
+			expectedError: "parsing raw time as JSON string",
+		},
+		"empty JSON string": {
+			jsonValue:     `""`,
+			expectedError: "parsing time",
+		},
+		"RFC3339 timestamp": {
+			jsonValue:     `"2006-01-02T15:04:05+07:00"`,
+			expectedValue: TimeWithOptionalZone(time.Date(2006, 1, 2, 8, 4, 5, 0, time.UTC)),
+		},
+		"ISO8601 timestamp without timezone": {
+			jsonValue:     `"2006-01-02T15:04:05"`,
+			expectedValue: TimeWithOptionalZone(time.Date(2006, 1, 2, 15, 4, 5, 0, laLoc)),
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			var value TimeWithOptionalZone
+			err := json.Unmarshal([]byte(testCase.jsonValue), &value)
+			if testCase.expectedError != "" {
+				assert.ErrorContains(err, testCase.expectedError)
+			} else {
+				assert.NoError(err)
+				assert.WithinDuration(testCase.expectedValue.Time(), value.Time(), 0)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a fix to accommodate an issue with Elation API where a time value is not being returned in the expected RFC 3339 format. As a fallback, it attempts to parse the time value as an ISO 8601 time in the Pacific timezone. 