### PR TITLE
Remove omitempty tag from BillCreate cpts

### DIFF
--- a/bill.go
+++ b/bill.go
@@ -62,7 +62,7 @@ type BillCreate struct {
 	Patient             int64         `json:"patient"`                        //: 64901939201, // required
 	Practice            int64         `json:"practice"`                       //: 65540, 		   // required
 	Physician           int64         `json:"physician"`                      //: 64811630594, // required
-	CPTs                []*BillCPT    `json:"cpts,omitempty"`                 //: [{}],
+	CPTs                []*BillCPT    `json:"cpts"`                           //: [{}],        // required
 	BillingProvider     int64         `json:"billing_provider,omitempty"`     //: 42120898,
 	RenderingProvider   int64         `json:"rendering_provider,omitempty"`   //: 68382673,
 	SupervisingProvider int64         `json:"supervising_provider,omitempty"` //: 52893234,

--- a/bill_test.go
+++ b/bill_test.go
@@ -22,6 +22,7 @@ func TestBillService_Create(t *testing.T) {
 				Patient:         64901939201,
 				Practice:        65540,
 				Physician:       64811630594,
+				CPTs:            []*BillCPT{},
 			},
 		},
 		"all specified fields request": {
@@ -110,6 +111,7 @@ func TestBillService_Create_already_exists(t *testing.T) {
 		Patient:         64901939201,
 		Practice:        65540,
 		Physician:       64811630594,
+		CPTs:            []*BillCPT{},
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The `cpts` field is required by the bill creation API, however it can be empty, so an empty non-nil slice should be allowed here.