### PR TITLE
Add Find and Get Bills API endpoint support

### DIFF
--- a/bill_test.go
+++ b/bill_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +24,7 @@ func TestBillService_Create(t *testing.T) {
 				Patient:         64901939201,
 				Practice:        65540,
 				Physician:       64811630594,
-				CPTs:            []*BillCPT{},
+				CPTs:            []*BillCPTCreate{},
 			},
 		},
 		"all specified fields request": {
@@ -32,7 +34,7 @@ func TestBillService_Create(t *testing.T) {
 				Patient:         64901939201,
 				Practice:        65540,
 				Physician:       64811630594,
-				CPTs: []*BillCPT{
+				CPTs: []*BillCPTCreate{
 					{
 						CPT:        "12",
 						Units:      "1.0",
@@ -111,7 +113,7 @@ func TestBillService_Create_already_exists(t *testing.T) {
 		Patient:         64901939201,
 		Practice:        65540,
 		Physician:       64811630594,
-		CPTs:            []*BillCPT{},
+		CPTs:            []*BillCPTCreate{},
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -151,4 +153,115 @@ func TestBillService_Create_already_exists(t *testing.T) {
 	assert.Nil(created)
 	assert.NotNil(res)
 	assert.ErrorIs(err, ErrBillExist)
+}
+
+func TestBillService_Find(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := &FindBillsOptions{
+		Pagination: &Pagination{
+			Limit:  1,
+			Offset: 2,
+		},
+
+		AssignedPhysician: []int64{1},
+		BillID:            []int64{2},
+		FromServiceDate:   time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC),
+		ToServiceDate:     time.Date(2023, 5, 20, 0, 0, 0, 0, time.UTC),
+		Patient:           []int64{3},
+		Practice:          []int64{4},
+		SigningPhysician:  []int64{5},
+		VisitNoteID:       []int64{6},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/bills", r.URL.Path)
+
+		assignedPhysician := r.URL.Query().Get("assigned_physician")
+		billID := r.URL.Query().Get("bill_id")
+		fromServiceDate := r.URL.Query().Get("from_service_date")
+		toServiceDate := r.URL.Query().Get("to_service_date")
+		patient := r.URL.Query().Get("patient")
+		practice := r.URL.Query().Get("practice")
+		signingPhysician := r.URL.Query().Get("signing_physician")
+		visitNoteID := r.URL.Query().Get("visit_note_id")
+
+		limit := r.URL.Query().Get("limit")
+		offset := r.URL.Query().Get("offset")
+
+		assert.Equal(opts.AssignedPhysician, sliceStrToInt64([]string{assignedPhysician}))
+		assert.Equal(opts.BillID, sliceStrToInt64([]string{billID}))
+		assert.Equal(opts.FromServiceDate.Format(time.RFC3339), fromServiceDate)
+		assert.Equal(opts.ToServiceDate.Format(time.RFC3339), toServiceDate)
+		assert.Equal(opts.Patient, sliceStrToInt64([]string{patient}))
+		assert.Equal(opts.Practice, sliceStrToInt64([]string{practice}))
+		assert.Equal(opts.SigningPhysician, sliceStrToInt64([]string{signingPhysician}))
+		assert.Equal(opts.VisitNoteID, sliceStrToInt64([]string{visitNoteID}))
+
+		assert.Equal(opts.Limit, strToInt(limit))
+		assert.Equal(opts.Offset, strToInt(offset))
+
+		b, err := json.Marshal(Response[[]*Bill]{
+			Results: []*Bill{
+				{
+					ID: 1,
+				},
+				{
+					ID: 2,
+				},
+			},
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := BillService{client}
+
+	found, res, err := svc.Find(context.Background(), opts)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
+}
+
+func TestBillService_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	var id int64 = 1
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tokenRequest(w, r) {
+			return
+		}
+
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/bills/"+strconv.FormatInt(id, 10), r.URL.Path)
+
+		b, err := json.Marshal(&Patient{
+			ID: id,
+		})
+		assert.NoError(err)
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint
+		w.Write(b)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
+	svc := BillService{client}
+
+	found, res, err := svc.Get(context.Background(), id)
+	assert.NotNil(found)
+	assert.NotNil(res)
+	assert.NoError(err)
 }


### PR DESCRIPTION
https://docs.elationhealth.com/reference/the-bill-object

Also addresses a type error in the `Payment` field

Note that the results -> cpts -> dxes fields differ between the [Create](https://docs.elationhealth.com/reference/bills_create) and [Find](https://docs.elationhealth.com/reference/bills_list)/[Get](https://docs.elationhealth.com/reference/bills_retrieve) endpoints so this also updates the `Bill` type to reflect that