### PR TITLE
Revert "Add Find and Get Bills (#129)"

### DIFF
--- a/bill.go
+++ b/bill.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strconv"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -30,74 +28,61 @@ type BillService struct {
 }
 
 type Bill struct {
-	ID                   int64           `json:"id"`                      //: 65099661468,
-	RefNumber            *string         `json:"ref_number"`              //: null,                        // string(50). required for PATCH that marks bill as processed.
-	ServiceDate          time.Time       `json:"service_date"`            //: "2016-10-12T12:00:00Z",
-	BillingDate          *time.Time      `json:"billing_date"`            //: null,                        // datetime(iso8601). required for PATCH that marks bill as processed.
-	BillingStatus        string          `json:"billing_status"`          //: "Unbilled",
-	BillingError         *string         `json:"billing_error"`           //: null,                        // string(200). required for PATCH that marks bill as failed.
-	BillingRawError      *string         `json:"billing_raw_error"`       //: null,                        // longtext. optional for PATCH that marks bill as failed.
-	Notes                string          `json:"notes"`                   //: "patient has not paid yet",
-	CPTs                 []*BillCPT      `json:"cpts"`                    //: [{}],
-	Payment              BillPayment     `json:"payment"`                 //: {"amount": "10.00","when_collected": "2016-10-12T22:11:01Z"}
-	VisitNote            int64           `json:"visit_note"`              //: 64409108504,
-	VisitNoteSignedDate  time.Time       `json:"visit_note_signed_date"`  //: "2016-10-12T22:11:01Z",
-	VisitNoteDeletedDate *time.Time      `json:"visit_note_deleted_date"` //: null,
-	ReferringProvider    *BillProvider   `json:"referring_provider"`      //: {},
-	BillingProvider      *int64          `json:"billing_provider"`        //: 42120898,
-	RenderingProvider    *int64          `json:"rendering_provider"`      //: 68382673,
-	SupervisingProvider  *int64          `json:"supervising_provider"`    //: 52893234,
-	OrderingProvider     *BillProvider   `json:"ordering_provider"`       //: {}
-	ServiceLocation      ServiceLocation `json:"service_location"`        //: 141103949480183,
-	Physician            int64           `json:"physician"`               //: 64811630594,
-	Practice             int64           `json:"practice"`                //: 65540,
-	Patient              int64           `json:"patient"`                 //: 64901939201,
-	PriorAuthorization   *string         `json:"prior_authorization"`     //: "1234-ABC",
-	Metadata             any             `json:"metadata"`                //: null,
-	CreatedDate          time.Time       `json:"created_date"`            //: "2016-05-23T17:50:50Z",
-	LastModifiedDate     time.Time       `json:"last_modified_date"`      //: "2016-10-12T22:39:46Z"
+	ID                   int64         `json:"id"`                      //: 65099661468,
+	RefNumber            *string       `json:"ref_number"`              //: null,                        // string(50). required for PATCH that marks bill as processed.
+	ServiceDate          time.Time     `json:"service_date"`            //: "2016-10-12T12:00:00Z",
+	BillingDate          *time.Time    `json:"billing_date"`            //: null,                        // datetime(iso8601). required for PATCH that marks bill as processed.
+	BillingStatus        string        `json:"billing_status"`          //: "Unbilled",
+	BillingError         *string       `json:"billing_error"`           //: null,                        // string(200). required for PATCH that marks bill as failed.
+	BillingRawError      *string       `json:"billing_raw_error"`       //: null,                        // longtext. optional for PATCH that marks bill as failed.
+	Notes                string        `json:"notes"`                   //: "patient has not paid yet",
+	CPTs                 []*BillCPT    `json:"cpts"`                    //: [{}],
+	Payment              int64         `json:"payment"`                 //: 142502884606313,
+	VisitNote            int64         `json:"visit_note"`              //: 64409108504,
+	VisitNoteSignedDate  time.Time     `json:"visit_note_signed_date"`  //: "2016-10-12T22:11:01Z",
+	VisitNoteDeletedDate *time.Time    `json:"visit_note_deleted_date"` //: null,
+	ReferringProvider    *BillProvider `json:"referring_provider"`      //: {},
+	BillingProvider      *int64        `json:"billing_provider"`        //: 42120898,
+	RenderingProvider    *int64        `json:"rendering_provider"`      //: 68382673,
+	SupervisingProvider  *int64        `json:"supervising_provider"`    //: 52893234,
+	OrderingProvider     *BillProvider `json:"ordering_provider"`       //: {}
+	ServiceLocation      int64         `json:"service_location"`        //: 141103949480183,
+	Physician            int64         `json:"physician"`               //: 64811630594,
+	Practice             int64         `json:"practice"`                //: 65540,
+	Patient              int64         `json:"patient"`                 //: 64901939201,
+	PriorAuthorization   *string       `json:"prior_authorization"`     //: "1234-ABC",
+	Metadata             any           `json:"metadata"`                //: null,
+	CreatedDate          time.Time     `json:"created_date"`            //: "2016-05-23T17:50:50Z",
+	LastModifiedDate     time.Time     `json:"last_modified_date"`      //: "2016-10-12T22:39:46Z"
 }
 
 type BillCreate struct {
-	ServiceLocation     int64            `json:"service_location"`               //: 10           // required
-	VisitNote           int64            `json:"visit_note"`                     //: 64409108504, // required
-	Patient             int64            `json:"patient"`                        //: 64901939201, // required
-	Practice            int64            `json:"practice"`                       //: 65540, 		   // required
-	Physician           int64            `json:"physician"`                      //: 64811630594, // required
-	CPTs                []*BillCPTCreate `json:"cpts"`                           //: [{}],        // required
-	BillingProvider     int64            `json:"billing_provider,omitempty"`     //: 42120898,
-	RenderingProvider   int64            `json:"rendering_provider,omitempty"`   //: 68382673,
-	SupervisingProvider int64            `json:"supervising_provider,omitempty"` //: 52893234,
-	ReferringProvider   *BillProvider    `json:"referring_provider,omitempty"`   //: {},
-	OrderingProvider    *BillProvider    `json:"ordering_provider,omitempty"`    //: {},
-	PriorAuthorization  string           `json:"prior_authorization,omitempty"`  //: "1234-ABC",
-	PaymentAmount       float64          `json:"payment_amount,omitempty"`       //: 10.00,
-	Notes               string           `json:"notes,omitempty"`                //: "patient has not paid yet",
+	ServiceLocation     int64         `json:"service_location"`               //: 10           // required
+	VisitNote           int64         `json:"visit_note"`                     //: 64409108504, // required
+	Patient             int64         `json:"patient"`                        //: 64901939201, // required
+	Practice            int64         `json:"practice"`                       //: 65540, 		   // required
+	Physician           int64         `json:"physician"`                      //: 64811630594, // required
+	CPTs                []*BillCPT    `json:"cpts"`                           //: [{}],        // required
+	BillingProvider     int64         `json:"billing_provider,omitempty"`     //: 42120898,
+	RenderingProvider   int64         `json:"rendering_provider,omitempty"`   //: 68382673,
+	SupervisingProvider int64         `json:"supervising_provider,omitempty"` //: 52893234,
+	ReferringProvider   *BillProvider `json:"referring_provider,omitempty"`   //: {},
+	OrderingProvider    *BillProvider `json:"ordering_provider,omitempty"`    //: {},
+	PriorAuthorization  string        `json:"prior_authorization,omitempty"`  //: "1234-ABC",
+	PaymentAmount       float64       `json:"payment_amount,omitempty"`       //: 10.00,
+	Notes               string        `json:"notes,omitempty"`                //: "patient has not paid yet",
 }
 
 type BillDX struct {
 	ICD10Code string `json:"icd10_code"`
 }
-
-type BillCPTCreate struct {
+type BillCPT struct {
 	CPT        string   `json:"cpt"`                 //: "99213",
 	Modifiers  []string `json:"modifiers,omitempty"` //: ["10"],
 	DXs        []BillDX `json:"dxs"`                 //: ["D23.4"],
 	AltDXs     []string `json:"alt_dxs,omitempty"`   //: ["216.4"],
 	UnitCharge string   `json:"unit_charge"`         //: "10.0",
 	Units      string   `json:"units"`               //: "1.0"
-}
-
-type BillCPT struct {
-	CPT        string   `json:"cpt"`                   //: "99213",
-	Modifiers  []string `json:"modifiers,omitempty"`   //: ["10"],
-	DXs        []string `json:"dxs"`                   //: ["D23.4"],
-	AltDXs     []string `json:"alt_dxs,omitempty"`     //: ["216.4"],
-	NDC        string   `json:"ndc,omitempty"`         // : "60575-4112-01", 11 digit NDC code, zero padded to 5-4-2 format
-	NDCDose    string   `json:"ndc_dose,omitempty"`    // : "1.000", NDC units administered.  Precision to 3 decimal places
-	NDCMeasure string   `json:"ndc_measure,omitempty"` // : "ML", NDC unit of measure: null, "F2", "GR", "ME", "ML" or "UN"
-	UnitCharge string   `json:"unit_charge"`           //: "10.0", charge per CPT unit
-	Units      string   `json:"units"`                 //: "1.0", CPT units
 }
 
 type BillPayment struct {
@@ -155,49 +140,4 @@ func (b *BillService) Create(ctx context.Context, create *BillCreate) (*Bill, *h
 	}
 
 	return bill, res, nil
-}
-
-type FindBillsOptions struct {
-	*Pagination
-
-	AssignedPhysician []int64   `url:"assigned_physician,omitempty"`
-	BillID            []int64   `url:"bill_id,omitempty"`
-	FromServiceDate   time.Time `url:"from_service_date,omitempty"`
-	ToServiceDate     time.Time `url:"to_service_date,omitempty"`
-	Patient           []int64   `url:"patient,omitempty"`
-	Practice          []int64   `url:"practice,omitempty"`
-	SigningPhysician  []int64   `url:"signing_physician,omitempty"`
-	VisitNoteID       []int64   `url:"visit_note_id,omitempty"`
-}
-
-func (s *BillService) Find(ctx context.Context, opts *FindBillsOptions) (*Response[[]*Bill], *http.Response, error) {
-	ctx, span := s.client.tracer.Start(ctx, "find bills", trace.WithSpanKind(trace.SpanKindClient))
-	defer span.End()
-
-	out := &Response[[]*Bill]{}
-
-	res, err := s.client.request(ctx, http.MethodGet, "/bills", opts, nil, &out)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "error making request")
-		return nil, res, fmt.Errorf("making request: %w", err)
-	}
-
-	return out, res, nil
-}
-
-func (s *BillService) Get(ctx context.Context, id int64) (*Bill, *http.Response, error) {
-	ctx, span := s.client.tracer.Start(ctx, "get bill", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.Int64("elation.bill_id", id)))
-	defer span.End()
-
-	out := &Bill{}
-
-	res, err := s.client.request(ctx, http.MethodGet, "/bills/"+strconv.FormatInt(id, 10), nil, nil, &out)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "error making request")
-		return nil, res, fmt.Errorf("making request: %w", err)
-	}
-
-	return out, res, nil
 }

--- a/bill_test.go
+++ b/bill_test.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,7 +22,7 @@ func TestBillService_Create(t *testing.T) {
 				Patient:         64901939201,
 				Practice:        65540,
 				Physician:       64811630594,
-				CPTs:            []*BillCPTCreate{},
+				CPTs:            []*BillCPT{},
 			},
 		},
 		"all specified fields request": {
@@ -34,7 +32,7 @@ func TestBillService_Create(t *testing.T) {
 				Patient:         64901939201,
 				Practice:        65540,
 				Physician:       64811630594,
-				CPTs: []*BillCPTCreate{
+				CPTs: []*BillCPT{
 					{
 						CPT:        "12",
 						Units:      "1.0",
@@ -113,7 +111,7 @@ func TestBillService_Create_already_exists(t *testing.T) {
 		Patient:         64901939201,
 		Practice:        65540,
 		Physician:       64811630594,
-		CPTs:            []*BillCPTCreate{},
+		CPTs:            []*BillCPT{},
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,115 +151,4 @@ func TestBillService_Create_already_exists(t *testing.T) {
 	assert.Nil(created)
 	assert.NotNil(res)
 	assert.ErrorIs(err, ErrBillExist)
-}
-
-func TestBillService_Find(t *testing.T) {
-	assert := assert.New(t)
-
-	opts := &FindBillsOptions{
-		Pagination: &Pagination{
-			Limit:  1,
-			Offset: 2,
-		},
-
-		AssignedPhysician: []int64{1},
-		BillID:            []int64{2},
-		FromServiceDate:   time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC),
-		ToServiceDate:     time.Date(2023, 5, 20, 0, 0, 0, 0, time.UTC),
-		Patient:           []int64{3},
-		Practice:          []int64{4},
-		SigningPhysician:  []int64{5},
-		VisitNoteID:       []int64{6},
-	}
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if tokenRequest(w, r) {
-			return
-		}
-
-		assert.Equal(http.MethodGet, r.Method)
-		assert.Equal("/bills", r.URL.Path)
-
-		assignedPhysician := r.URL.Query().Get("assigned_physician")
-		billID := r.URL.Query().Get("bill_id")
-		fromServiceDate := r.URL.Query().Get("from_service_date")
-		toServiceDate := r.URL.Query().Get("to_service_date")
-		patient := r.URL.Query().Get("patient")
-		practice := r.URL.Query().Get("practice")
-		signingPhysician := r.URL.Query().Get("signing_physician")
-		visitNoteID := r.URL.Query().Get("visit_note_id")
-
-		limit := r.URL.Query().Get("limit")
-		offset := r.URL.Query().Get("offset")
-
-		assert.Equal(opts.AssignedPhysician, sliceStrToInt64([]string{assignedPhysician}))
-		assert.Equal(opts.BillID, sliceStrToInt64([]string{billID}))
-		assert.Equal(opts.FromServiceDate.Format(time.RFC3339), fromServiceDate)
-		assert.Equal(opts.ToServiceDate.Format(time.RFC3339), toServiceDate)
-		assert.Equal(opts.Patient, sliceStrToInt64([]string{patient}))
-		assert.Equal(opts.Practice, sliceStrToInt64([]string{practice}))
-		assert.Equal(opts.SigningPhysician, sliceStrToInt64([]string{signingPhysician}))
-		assert.Equal(opts.VisitNoteID, sliceStrToInt64([]string{visitNoteID}))
-
-		assert.Equal(opts.Limit, strToInt(limit))
-		assert.Equal(opts.Offset, strToInt(offset))
-
-		b, err := json.Marshal(Response[[]*Bill]{
-			Results: []*Bill{
-				{
-					ID: 1,
-				},
-				{
-					ID: 2,
-				},
-			},
-		})
-		assert.NoError(err)
-
-		w.Header().Set("Content-Type", "application/json")
-		//nolint
-		w.Write(b)
-	}))
-	defer srv.Close()
-
-	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
-	svc := BillService{client}
-
-	found, res, err := svc.Find(context.Background(), opts)
-	assert.NotNil(found)
-	assert.NotNil(res)
-	assert.NoError(err)
-}
-
-func TestBillService_Get(t *testing.T) {
-	assert := assert.New(t)
-
-	var id int64 = 1
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if tokenRequest(w, r) {
-			return
-		}
-
-		assert.Equal(http.MethodGet, r.Method)
-		assert.Equal("/bills/"+strconv.FormatInt(id, 10), r.URL.Path)
-
-		b, err := json.Marshal(&Patient{
-			ID: id,
-		})
-		assert.NoError(err)
-
-		w.Header().Set("Content-Type", "application/json")
-		//nolint
-		w.Write(b)
-	}))
-	defer srv.Close()
-
-	client := NewHTTPClient(srv.Client(), srv.URL+"/token", "", "", srv.URL)
-	svc := BillService{client}
-
-	found, res, err := svc.Get(context.Background(), id)
-	assert.NotNil(found)
-	assert.NotNil(res)
-	assert.NoError(err)
 }


### PR DESCRIPTION
Reverts commit 8a3dd4e41420328a2e2ec0481908f0f522672043.

The Elation Bill APIs do not behave as documented (for example, the Bill response returned on Create does not match the type of the Get Bill Object), so prior changes cause errors in deserializing the response.