### PR TITLE
ART-3850 Support cursor pagination

### DIFF
--- a/cli/cmd/messaging.go
+++ b/cli/cmd/messaging.go
@@ -18,6 +18,11 @@ var findThreadMembersCmd = &cobra.Command{
 	Use: "find-thread-members",
 	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
 		response, _, err := client.ThreadMembers().Find(ctx, &elation.FindThreadMembersOptions{
+			Pagination: &elation.Pagination{
+				Cursor: paginationCursor,
+				Limit:  paginationLimit,
+				Offset: paginationOffset,
+			},
 			Patient: findThreadMembersPatients,
 			User:    findThreadMembersUsers,
 		})

--- a/cli/cmd/patient_document.go
+++ b/cli/cmd/patient_document.go
@@ -30,6 +30,7 @@ var findDiscontinuedMedications = &cobra.Command{
 	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
 		response, _, err := client.DiscontinuedMedications().Find(ctx, &elation.FindDiscontinuedMedicationsOptions{
 			Pagination: &elation.Pagination{
+				Cursor: paginationCursor,
 				Limit:  paginationLimit,
 				Offset: paginationOffset,
 			},
@@ -65,6 +66,7 @@ var findPrescriptionFills = &cobra.Command{
 	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
 		response, _, err := client.PrescriptionFills().Find(ctx, &elation.FindPrescriptionFillsOptions{
 			Pagination: &elation.Pagination{
+				Cursor: paginationCursor,
 				Limit:  paginationLimit,
 				Offset: paginationOffset,
 			},

--- a/cli/cmd/practice.go
+++ b/cli/cmd/practice.go
@@ -19,7 +19,13 @@ var (
 var findPhysiciansCmd = &cobra.Command{
 	Use: "find-physicians",
 	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
-		response, _, err := client.Physicians().Find(ctx, &elation.FindPhysiciansOptions{})
+		response, _, err := client.Physicians().Find(ctx, &elation.FindPhysiciansOptions{
+			Pagination: &elation.Pagination{
+				Cursor: paginationCursor,
+				Limit:  paginationLimit,
+				Offset: paginationOffset,
+			},
+		})
 		if err != nil {
 			return err
 		}
@@ -56,6 +62,7 @@ var listContactsCmd = &cobra.Command{
 	Run: wrapRunFunc(func(ctx context.Context, client elation.Client, args []string) error {
 		response, _, err := client.Contacts().List(ctx, &elation.ListContactsOptions{
 			Pagination: &elation.Pagination{
+				Cursor: paginationCursor,
 				Limit:  paginationLimit,
 				Offset: paginationOffset,
 			},

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	paginationCursor string
 	paginationLimit  int
 	paginationOffset int
 )
@@ -24,6 +25,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.PersistentFlags().StringVar(&paginationCursor, "cursor", "", "")
 	rootCmd.PersistentFlags().IntVar(&paginationLimit, "limit", 0, "")
 	rootCmd.PersistentFlags().IntVar(&paginationOffset, "offset", 0, "")
 }

--- a/client.go
+++ b/client.go
@@ -263,27 +263,18 @@ func (r *Response[ResultsT]) HasNext() bool {
 }
 
 func (r *Response[ResultsT]) PaginationNext() *Pagination {
-	return &Pagination{
-		Cursor: parseCursor(r.Next),
-		Limit:  parseLimit(r.Next),
-		Offset: parseOffset(r.Next),
-	}
+	return parsePagination(r.Next)
 }
 
 func (r *Response[ResultsT]) PaginationPrevious() *Pagination {
-	return &Pagination{
-		Cursor: parseCursor(r.Previous),
-		Limit:  parseLimit(r.Previous),
-		Offset: parseOffset(r.Previous),
-	}
+	return parsePagination(r.Previous)
 }
 
 func (r *Response[ResultsT]) PaginationNextWithLimit(limit int) *Pagination {
-	return &Pagination{
-		Cursor: parseCursor(r.Next),
-		Limit:  limit,
-		Offset: parseOffset(r.Next),
-	}
+	p := parsePagination(r.Next)
+	p.Limit = limit
+
+	return p
 }
 
 type Error struct {
@@ -360,39 +351,27 @@ func (c *HTTPClient) request(ctx context.Context, method string, path string, qu
 	return res, nil
 }
 
-func parseCursor(v string) string {
-	u, err := url.Parse(v)
-	if err != nil {
-		return ""
+func parsePagination(v string) *Pagination {
+	p := &Pagination{
+		Limit: defaultPaginationLimit,
 	}
 
-	return u.Query().Get("cursor")
-}
-
-func parseLimit(v string) int {
 	u, err := url.Parse(v)
 	if err != nil {
-		return defaultPaginationLimit
+		return p
 	}
 
-	offset, err := strconv.Atoi(u.Query().Get("limit"))
-	if err != nil {
-		return defaultPaginationLimit
-	}
+	p.Cursor = u.Query().Get("cursor")
 
-	return offset
-}
-
-func parseOffset(v string) int {
-	u, err := url.Parse(v)
-	if err != nil {
-		return 0
+	limit, err := strconv.Atoi(u.Query().Get("limit"))
+	if err == nil {
+		p.Limit = limit
 	}
 
 	offset, err := strconv.Atoi(u.Query().Get("offset"))
-	if err != nil {
-		return 0
+	if err == nil {
+		p.Offset = offset
 	}
 
-	return offset
+	return p
 }

--- a/client.go
+++ b/client.go
@@ -264,6 +264,7 @@ func (r *Response[ResultsT]) HasNext() bool {
 
 func (r *Response[ResultsT]) PaginationNext() *Pagination {
 	return &Pagination{
+		Cursor: parseCursor(r.Next),
 		Limit:  parseLimit(r.Next),
 		Offset: parseOffset(r.Next),
 	}
@@ -271,6 +272,7 @@ func (r *Response[ResultsT]) PaginationNext() *Pagination {
 
 func (r *Response[ResultsT]) PaginationPrevious() *Pagination {
 	return &Pagination{
+		Cursor: parseCursor(r.Previous),
 		Limit:  parseLimit(r.Previous),
 		Offset: parseOffset(r.Previous),
 	}
@@ -278,6 +280,7 @@ func (r *Response[ResultsT]) PaginationPrevious() *Pagination {
 
 func (r *Response[ResultsT]) PaginationNextWithLimit(limit int) *Pagination {
 	return &Pagination{
+		Cursor: parseCursor(r.Next),
 		Limit:  limit,
 		Offset: parseOffset(r.Next),
 	}
@@ -289,8 +292,9 @@ type Error struct {
 }
 
 type Pagination struct {
-	Limit  int `url:"limit,omitempty"`
-	Offset int `url:"offset,omitempty"`
+	Cursor string `url:"cursor,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	Offset int    `url:"offset,omitempty"`
 }
 
 func (e Error) Error() string {
@@ -354,6 +358,15 @@ func (c *HTTPClient) request(ctx context.Context, method string, path string, qu
 	}
 
 	return res, nil
+}
+
+func parseCursor(v string) string {
+	u, err := url.Parse(v)
+	if err != nil {
+		return ""
+	}
+
+	return u.Query().Get("cursor")
 }
 
 func parseLimit(v string) int {

--- a/client_test.go
+++ b/client_test.go
@@ -31,31 +31,97 @@ func TestResponse_HasNext(t *testing.T) {
 }
 
 func TestResponse_PaginationNext_PaginationPrevious(t *testing.T) {
-	assert := assert.New(t)
-
 	res := &Response[*resource]{}
 
-	assert.Equal(&Pagination{
-		Limit:  defaultPaginationLimit,
-		Offset: 0,
-	}, res.PaginationNext())
+	t.Run("it returns defaults when there is no next or previous URL", func(t *testing.T) {
+		assert := assert.New(t)
 
-	assert.Equal(&Pagination{
-		Limit:  defaultPaginationLimit,
-		Offset: 0,
-	}, res.PaginationPrevious())
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  defaultPaginationLimit,
+			Offset: 0,
+		}, res.PaginationNext())
 
-	res.Next = "https://domain.com/foo?limit=5&offset=10"
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  defaultPaginationLimit,
+			Offset: 0,
+		}, res.PaginationPrevious())
+	})
 
-	assert.Equal(&Pagination{
-		Limit:  5,
-		Offset: 10,
-	}, res.PaginationNext())
+	t.Run("it returns the limit and offset from the next and previous URLs", func(t *testing.T) {
+		assert := assert.New(t)
+		res.Next = "https://domain.com/foo?limit=5&offset=10"
 
-	res.Previous = "https://domain.com/foo?limit=15&offset=20"
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  5,
+			Offset: 10,
+		}, res.PaginationNext())
 
-	assert.Equal(&Pagination{
-		Limit:  15,
-		Offset: 20,
-	}, res.PaginationPrevious())
+		res.Previous = "https://domain.com/foo?limit=15&offset=20"
+
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  15,
+			Offset: 20,
+		}, res.PaginationPrevious())
+	})
+
+	t.Run("it returns the cursor and limit from the next and previous URLs", func(t *testing.T) {
+		assert := assert.New(t)
+		res.Next = "https://domain.com/foo?cursor=abc123&limit=5"
+
+		assert.Equal(&Pagination{
+			Cursor: "abc123",
+			Limit:  5,
+			Offset: 0,
+		}, res.PaginationNext())
+
+		res.Previous = "https://domain.com/foo?cursor=def456&limit=10"
+
+		assert.Equal(&Pagination{
+			Cursor: "def456",
+			Limit:  10,
+			Offset: 0,
+		}, res.PaginationPrevious())
+	})
+}
+
+func TestResponse_PaginationNextWithLimit(t *testing.T) {
+	res := &Response[*resource]{}
+
+	limit := 11
+
+	t.Run("it returns the passed-in limit and the defaults when there is no next URL", func(t *testing.T) {
+		assert := assert.New(t)
+
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  limit,
+			Offset: 0,
+		}, res.PaginationNextWithLimit(limit))
+	})
+
+	t.Run("it returns the passed-in limit and the offset from the next URL", func(t *testing.T) {
+		assert := assert.New(t)
+		res.Next = "https://domain.com/foo?limit=5&offset=10"
+
+		assert.Equal(&Pagination{
+			Cursor: "",
+			Limit:  limit,
+			Offset: 10,
+		}, res.PaginationNextWithLimit(limit))
+	})
+
+	t.Run("it returns the passed-in limit and the cursor from the next URL", func(t *testing.T) {
+		assert := assert.New(t)
+		res.Next = "https://domain.com/foo?cursor=abc123&limit=5"
+
+		assert.Equal(&Pagination{
+			Cursor: "abc123",
+			Limit:  limit,
+			Offset: 0,
+		}, res.PaginationNextWithLimit(limit))
+	})
 }


### PR DESCRIPTION
This PR adds support for [cursor pagination](https://docs.elationhealth.com/reference/pagination#cursor-based-pagination) to the APIs that support pagination. It also updates the CLI subcommands to accept the pagination flags where the API supports pagination.